### PR TITLE
Dynamic label width

### DIFF
--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -29,7 +29,8 @@ defmodule Benchee.Formatters.Console do
   def format(jobs) do
     sorted = Statistics.sort(jobs)
     label_width = label_width jobs
-    [column_descriptors(label_width) | job_reports(sorted, label_width) ++ comparison_report(sorted, label_width)]
+    [column_descriptors(label_width) | job_reports(sorted, label_width)
+      ++ comparison_report(sorted, label_width)]
     |> remove_last_blank_line
   end
 
@@ -93,8 +94,10 @@ defmodule Benchee.Formatters.Console do
     [] # No need for a comparison when only one benchmark was run
   end
   defp comparison_report([reference | other_jobs], label_width) do
-    report = [reference_report(reference, label_width) | comparisons(reference, label_width, other_jobs)]
-    [comparison_descriptor | report]
+    [
+      comparison_descriptor(), reference_report(reference, label_width) |
+      comparisons(reference, label_width, other_jobs)
+    ]
   end
 
   defp reference_report({name, %{ips: ips}}, label_width) do

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -95,7 +95,8 @@ defmodule Benchee.Formatters.Console do
   end
   defp comparison_report([reference | other_jobs], label_width) do
     [
-      comparison_descriptor(), reference_report(reference, label_width) |
+      comparison_descriptor,
+      reference_report(reference, label_width) |
       comparisons(reference, label_width, other_jobs)
     ]
   end

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -6,7 +6,7 @@ defmodule Benchee.Formatters.Console do
 
   alias Benchee.Statistics
 
-  @default_label_width 29
+  @default_label_width 4 # Length of column header
   @ips_width 13
   @average_width 15
   @deviation_width 13
@@ -20,8 +20,8 @@ defmodule Benchee.Formatters.Console do
   ```
   iex> jobs = [{"My Job", %{average: 200.0, ips: 5000.0, std_dev_ratio: 0.1, median: 190.0}}]
   iex> Benchee.Formatters.Console.format(jobs)
-  ["\nName                                    ips        average    deviation         median\n",
-  "My Job                              5000.00       200.00μs    (±10.00%)       190.00μs"]
+  ["\nName             ips        average    deviation         median\n",
+  "My Job       5000.00       200.00μs    (±10.00%)       190.00μs"]
 
   ```
 

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -29,7 +29,7 @@ defmodule Benchee.Formatters.Console do
   def format(jobs) do
     sorted = Statistics.sort(jobs)
     label_width = label_width jobs
-    [column_descriptors(label_width) | job_reports(sorted, label_width) ++ comparison_report(sorted)]
+    [column_descriptors(label_width) | job_reports(sorted, label_width) ++ comparison_report(sorted, label_width)]
     |> remove_last_blank_line
   end
 
@@ -88,29 +88,29 @@ defmodule Benchee.Formatters.Console do
     |> to_string
   end
 
-  defp comparison_report([_reference]) do
+  defp comparison_report([_reference], _) do
     [] # No need for a comparison when only one benchmark was run
   end
-  defp comparison_report([reference | other_jobs]) do
-    report = [reference_report(reference) | comparisons(reference, other_jobs)]
+  defp comparison_report([reference | other_jobs], label_width) do
+    report = [reference_report(reference, label_width) | comparisons(reference, label_width, other_jobs)]
     [comparison_descriptor | report]
   end
 
-  defp reference_report({name, %{ips: ips}}) do
+  defp reference_report({name, %{ips: ips}}, label_width) do
     "~*s~*.2f\n"
-    |> :io_lib.format([-@label_width, name, @ips_width, ips])
+    |> :io_lib.format([-label_width, name, @ips_width, ips])
     |> to_string
   end
 
-  defp comparisons({_, reference_stats}, jobs_to_compare) do
+  defp comparisons({_, reference_stats}, label_width, jobs_to_compare) do
     Enum.map jobs_to_compare, fn(job = {_, job_stats}) ->
-      format_comparison(job, (reference_stats.ips / job_stats.ips))
+      format_comparison(job, label_width, (reference_stats.ips / job_stats.ips))
     end
   end
 
-  defp format_comparison({name, %{ips: ips}}, times_slower) do
+  defp format_comparison({name, %{ips: ips}}, label_width, times_slower) do
     "~*s~*.2f - ~.2fx slower\n"
-    |> :io_lib.format([-@label_width, name, @ips_width, ips, times_slower])
+    |> :io_lib.format([-label_width, name, @ips_width, ips, times_slower])
     |> to_string
   end
 

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -6,7 +6,7 @@ defmodule Benchee.Formatters.Console do
 
   alias Benchee.Statistics
 
-  @label_width 30
+  @default_label_width 29
   @ips_width 13
   @average_width 15
   @deviation_width 13
@@ -42,10 +42,11 @@ defmodule Benchee.Formatters.Console do
   end
 
   defp label_width(jobs) do
-    jobs
-      |> Enum.map(fn({job_name, _}) -> String.length(job_name) + 1 end)
-      |> Stream.concat([@label_width])
+    max_label_width = jobs
+      |> Enum.map(fn({job_name, _}) -> String.length(job_name) end)
+      |> Stream.concat([@default_label_width])
       |> Enum.max
+    max_label_width + 1
   end
 
   defp job_reports(jobs, label_width) do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -30,20 +30,20 @@ defmodule Benchee.Formatters.ConsoleTest do
     third  = {third_name,  %{average: 400.0, ips: 2_500.0,
                              std_dev_ratio: 0.1, median: 375.0}}
 
-    # Just normally long names, expect default width of 30 + 13
+    expected_width = 43 # Normally long names, expect default width of 30 + 13
     [header, result_1, result_2 | _dont_care ] = Console.format([first, second])
 
-    assert_column_width "Name", header, 43
-    assert_column_width "First", result_1, 43
-    assert_column_width "Second", result_2, 43
+    assert_column_width "Name", header, expected_width
+    assert_column_width "First", result_1, expected_width
+    assert_column_width "Second", result_2, expected_width
 
-    # Include extra long name, expect width of 41 + 13 == 54
+    expected_width_wide = 54 # Include extra long name, expect width of 41 + 13
     [header, result_1, result_2, result_3 | _dont_care ] = Console.format([first, second, third])
 
-    assert_column_width "Name", header, 54
-    assert_column_width "First", result_1, 54
-    assert_column_width "Second", result_2, 54
-    assert_column_width third_name, result_3, 54
+    assert_column_width "Name", header, expected_width_wide
+    assert_column_width "First", result_1, expected_width_wide
+    assert_column_width "Second", result_2, expected_width_wide
+    assert_column_width third_name, result_3, expected_width_wide
   end
 
   test "creates comparisons" do
@@ -68,11 +68,11 @@ defmodule Benchee.Formatters.ConsoleTest do
     second  = {second_name,  %{average: 400.0, ips: 2_500.0,
                                std_dev_ratio: 0.1, median: 375.0}}
 
-    # Include extra long name, expect width of 41 + 13 == 54
+    expected_width = 54 # With extra long name, expect width of 41 + 13
     [_, _, _, _comp_header, reference, slower] = Console.format([first, second])
 
-    assert_column_width "First", reference, 54
-    assert_column_width second_name, slower, 54
+    assert_column_width "First", reference, expected_width
+    assert_column_width second_name, slower, expected_width
   end
 
   test "it doesn't create comparisons with only one benchmark run" do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -31,7 +31,7 @@ defmodule Benchee.Formatters.ConsoleTest do
                              std_dev_ratio: 0.1, median: 375.0}}
 
     # Normally long names, expect default minimum width of 29 characters.
-    expected_width = 29
+    expected_width = 6
     [header, result_1, result_2 | _dont_care ] = Console.format([first, second])
 
     assert_column_width "Name", header, expected_width

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -30,14 +30,16 @@ defmodule Benchee.Formatters.ConsoleTest do
     third  = {third_name,  %{average: 400.0, ips: 2_500.0,
                              std_dev_ratio: 0.1, median: 375.0}}
 
-    expected_width = 43 # Normally long names, expect default width of 30 + 13
+    # Normally long names, expect default minimum width of 29 characters.
+    expected_width = 29
     [header, result_1, result_2 | _dont_care ] = Console.format([first, second])
 
     assert_column_width "Name", header, expected_width
     assert_column_width "First", result_1, expected_width
     assert_column_width "Second", result_2, expected_width
 
-    expected_width_wide = 54 # Include extra long name, expect width of 41 + 13
+    # Include extra long name, expect width of 40 characters
+    expected_width_wide = 40
     [header, result_1, result_2, result_3 | _dont_care ] = Console.format([first, second, third])
 
     assert_column_width "Name", header, expected_width_wide
@@ -68,7 +70,7 @@ defmodule Benchee.Formatters.ConsoleTest do
     second  = {second_name,  %{average: 400.0, ips: 2_500.0,
                                std_dev_ratio: 0.1, median: 375.0}}
 
-    expected_width = 54 # With extra long name, expect width of 41 + 13
+    expected_width = 40 # With extra long name, expect width of 40 characters
     [_, _, _, _comp_header, reference, slower] = Console.format([first, second])
 
     assert_column_width "First", reference, expected_width
@@ -114,10 +116,13 @@ defmodule Benchee.Formatters.ConsoleTest do
   end
 
   defp assert_column_width(name, string, expected_width) do
+    # add 13 characters for the ips column, and an extra space between the columns
+    expected_width = expected_width + 14
     n = Regex.escape name
     regex = Regex.compile! "(#{n} +([0-9\.]+|ips))( |$)"
     assert Regex.match? regex, string
     assert expected_width == Regex.run(regex, string, capture: :all_but_first)
-      |> hd() |> String.length()
+                             |> hd
+                             |> String.length
   end
 end


### PR DESCRIPTION
Makes the Console formatter increase the label column width if any test name is longer than 29 characters/graphemes.

Fixes https://github.com/PragTob/benchee/issues/11

Do we want to keep the default/minimum 30 character width, or remove/reduce it?

Feedback is appreciated.

