### PR TITLE
Introduce retrying helper to deal with flaky tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Benchee.Mixfile do
       app: :benchee,
       version: "0.2.0",
       elixir: "~> 1.2",
+      elixirc_paths: elixirc_paths(Mix.env),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps,
@@ -18,6 +19,9 @@ defmodule Benchee.Mixfile do
       """
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   def application do
     [applications: [:logger]]

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,16 @@
+defmodule Benchee.TestHelpers do
+  # retry tests that are doing actual benchmarking and are flaky
+  # on overloaded and/or slower systems
+  def retrying(asserting_function, n \\ 5)
+  def retrying(asserting_function, 1) do
+    asserting_function.()
+  end
+  def retrying(asserting_function, n) do
+    try do
+      asserting_function.()
+    rescue
+      ExUnit.AssertionError ->
+        retrying(asserting_function, n - 1)
+    end
+  end
+end


### PR DESCRIPTION
* On overloaded/slower systems it seems the tests are flaky,
  adjust some numbers a bit and add a retrying helper that
  gives a test the chance to execute 5 times before failing it
* makes for i in {1..8}; do mix test test/benchee/benchmark_test.exs & done
  constantly succeed on my system whereas before it would fail constantly

Fixes #12 

@alvinlindstam: wanna have a look/want to try this branch out to see if it works better for you? :)