### PR TITLE
Add parallel benchmarking capability.

### DIFF
--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -66,7 +66,7 @@ defmodule Benchee do
 
   ## Examples
 
-      iex> run_times = [200, 400, 400, 400, 500, 500, 700, 900]
+      iex> run_times = [[200, 400, 400, 400, 500, 500, 700, 900]]
       iex> suite = %{run_times: [{"My Job", run_times}]}
       iex> Benchee.Statistics.statistics(suite)
       [{"My Job",

--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -45,7 +45,7 @@ defmodule Benchee.Benchmark do
     # only run func through Task.async when >1 parallel is requiested
     case collection do
       [arg] ->
-        func.(arg)
+        [func.(arg)]
       parallel ->
         parallel
         |> Enum.map(&Task.async(fn -> func.(&1) end))

--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -44,8 +44,8 @@ defmodule Benchee.Benchmark do
   defp pmap(collection, func) do
     # only run func through Task.async when >1 parallel is requiested
     case collection do
-      [arg] ->
-        [func.(arg)]
+      1..1 ->
+        [func.(1)]
       parallel ->
         parallel
         |> Enum.map(&Task.async(fn -> func.(&1) end))

--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -42,9 +42,15 @@ defmodule Benchee.Benchmark do
   end
 
   defp pmap(collection, func) do
-    collection
-    |> Enum.map(&Task.async(fn -> func.(&1) end))
-    |> Enum.map(&Task.await(&1, :infinity))
+    # only run func through Task.async when >1 parallel is requiested
+    case collection do
+      [arg] ->
+        func.(arg)
+      parallel ->
+        parallel
+        |> Enum.map(&Task.async(fn -> func.(&1) end))
+        |> Enum.map(&Task.await(&1, :infinity))
+    end
   end
 
   defp run_warmup(function, time) do

--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -31,7 +31,7 @@ defmodule Benchee.Benchmark do
   """
   def measure(suite = %{jobs: jobs, config: %{parallel: parallel, time: time, warmup: warmup}}) do
     run_times = Enum.map jobs, fn({name, function}) ->
-      IO.puts "Benchmarking name: #{name}, parallel: #{parallel}, time: #{time / 1_000_000}, warmup: #{warmup / 1_000_000}..."
+      IO.puts "Benchmarking #{name}..."
       job_run_times = pmap 1..parallel, fn(_) ->
         run_warmup function, warmup
         measure_runtimes function, time

--- a/lib/benchee/config.ex
+++ b/lib/benchee/config.ex
@@ -12,20 +12,22 @@ defmodule Benchee.Config do
 
   Possible options:
 
-    * time   - total run time in seconds of a single benchmark (determines how
-      often it is executed). Defaults to 5.
-    * warmup - the time in seconds for which the benchmarking function should be run without gathering results. Defaults to 2.
+    * parallel - the amount of parallel processes that are spawned to run the benchmark in
+    * time     - total run time in seconds of a single benchmark (determines how
+                 often it is executed). Defaults to 5.
+    * warmup   - the time in seconds for which the benchmarking function should be run
+                 without gathering results. Defaults to 2.
 
   ## Examples
 
       iex> Benchee.init
-      %{config: %{time: 5_000_000, warmup: 2_000_000}, jobs: []}
+      %{config: %{parallel: 1, time: 5_000_000, warmup: 2_000_000}, jobs: []}
 
       iex> Benchee.init %{time: 1, warmup: 0.2}
-      %{config: %{time: 1_000_000, warmup: 200_000.0}, jobs: []}
+      %{config: %{parallel: 1, time: 1_000_000, warmup: 200_000.0}, jobs: []}
 
   """
-  @default_config %{time: 5, warmup: 2}
+  @default_config %{parallel: 1, time: 5, warmup: 2}
   @time_keys [:time, :warmup]
   def init(config \\ %{}) do
     config = convert_time_to_micro_s(Map.merge(@default_config, config))

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -67,14 +67,16 @@ defmodule Benchee.Statistics do
 
   """
   def job_statistics(run_times) do
-    total_time          = Enum.sum(run_times)
-    iterations          = Enum.count(run_times)
+    flat_run_times      = List.flatten(run_times)
+    parallel            = length(run_times)
+    total_time          = Enum.sum(flat_run_times)
+    iterations          = Enum.count(flat_run_times)
     average             = total_time / iterations
-    ips                 = iterations_per_second(iterations, total_time)
-    deviation           = standard_deviation(run_times, average, iterations)
+    ips                 = iterations_per_second(iterations, total_time) * parallel
+    deviation           = standard_deviation(flat_run_times, average, iterations)
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
-    median              = compute_median(run_times, iterations)
+    median              = compute_median(flat_run_times, iterations)
 
     %{
       average:       average,

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -32,7 +32,7 @@ defmodule Benchee.Statistics do
 
   ## Examples
 
-      iex> run_times = [200, 400, 400, 400, 500, 500, 700, 900]
+      iex> run_times = [[200, 400, 400, 400, 500, 500, 700, 900]]
       iex> suite = %{run_times: [{"My Job", run_times}]}
       iex> Benchee.Statistics.statistics(suite)
       [{"My Job",
@@ -56,7 +56,7 @@ defmodule Benchee.Statistics do
 
   ## Examples
 
-      iex> run_times = [200, 400, 400, 400, 500, 500, 700, 900]
+      iex> run_times = [[200, 400, 400, 400, 500, 500, 700, 900]]
       iex> Benchee.Statistics.job_statistics(run_times)
       %{average:       500.0,
         ips:           2000.0,

--- a/samples/parallel_process.exs
+++ b/samples/parallel_process.exs
@@ -1,0 +1,16 @@
+# When passing a flag parallel with value >1 then multiple processes
+# will be handled for benchmarking provided function.
+
+Benchee.run %{parallel: 5, time: 10}, [{"five", fn -> :timer.sleep(1000) end}]
+
+#iex(1)> Benchee.run %{time: 10}, [{"one", fn -> :timer.sleep(1000) end}]
+#Benchmarking name: one, parallel: 1, time: 10.0, warmup: 2.0...
+#
+#Name           ips        average    deviation         median
+#one             1.00   1004495.78μs     (±0.15%)   1005146.00μs
+
+#iex(2)> Benchee.run %{parallel: 5, time: 10}, [{"five", fn -> :timer.sleep(1000) end}]
+#Benchmarking name: five, parallel: 5, time: 10.0, warmup: 2.0...
+#
+#Name           ips        average    deviation         median
+#five            4.98   1003737.24μs     (±0.10%)   1003672.00μs

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -33,14 +33,14 @@ defmodule Benchee.BenchmarkTest do
 
   test ".measure can run multiple benchmarks in parallel" do
     capture_io fn ->
-      suite = %{config: %{parallel: 10, time: 100_000, warmup: 0}, jobs: [{"", fn -> :timer.sleep 10 end}]}
+      suite = %{config: %{parallel: 10, time: 50_000, warmup: 0}, jobs: [{"", fn -> :timer.sleep 10 end}]}
       new_suite = Benchee.measure suite
       [result1 | _tail] = new_suite.run_times
       {"", run_times} = result1
 
       assert length(run_times) == 10
-      # (as above) should be 90 (100 minus one prewarm per parallel) but gotta give it a bit leeway
-      assert length(List.flatten(run_times)) >= 80
+      # (as above) should be 40 (50 minus one prewarm per parallel) but gotta give it a bit leeway (even more since parallel)
+      assert length(List.flatten(run_times)) >= 20 # is at least faster than on process in parallel
     end
   end
 

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -16,7 +16,7 @@ defmodule Benchee.BenchmarkTest do
 
   test ".mease runs a benchmark suite and enriches it with results" do
     capture_io fn ->
-      suite = %{config: %{time: 100_000, warmup: 0}, jobs: []}
+      suite = %{config: %{parallel: 1, time: 100_000, warmup: 0}, jobs: []}
       new_suite =
         suite
         |> Benchee.benchmark("Name", fn -> :timer.sleep(10) end)
@@ -26,15 +26,16 @@ defmodule Benchee.BenchmarkTest do
       assert new_suite.config == suite.config
       assert [{name, run_times}] = new_suite.run_times
       assert name == "Name"
+      assert length(run_times) == 1
       # should be 9 (10 minus one prewarm) but gotta give it a bit leeway
-      assert Enum.count(run_times) >= 8
+      assert Enum.count(List.flatten(run_times)) >= 8
     end
   end
 
   test ".measure doesn't take longer than advertised for very fast funs" do
     capture_io fn ->
       projected = 10_000
-      suite = %{config: %{time: projected, warmup: 0},
+      suite = %{config: %{parallel: 1, time: projected, warmup: 0},
                 jobs: [{"", fn -> 0 end}]}
       {time, _} = :timer.tc fn -> Benchee.measure(suite) end
 
@@ -48,7 +49,7 @@ defmodule Benchee.BenchmarkTest do
       time      = 10_000
       warmup    = 5_000
       projected = time + warmup
-      suite = %{config: %{time: time, warmup: warmup},
+      suite = %{config: %{parallel: 1, time: time, warmup: warmup},
                 jobs: [{"", fn -> 0 end}]}
       {time, _} = :timer.tc fn -> Benchee.measure(suite) end
 
@@ -60,7 +61,7 @@ defmodule Benchee.BenchmarkTest do
   test "variance does not skyrocket on very fast functions" do
     capture_io fn ->
       range = 0..10
-      stats = %{config: %{time: 100_000, warmup: 20_000}, jobs: []}
+      stats = %{config: %{parallel: 1, time: 100_000, warmup: 20_000}, jobs: []}
               |> Benchee.benchmark("noop", fn -> 0 end)
               |> Benchee.benchmark("map", fn ->
                    Enum.map(range, fn(i) -> i end)
@@ -76,7 +77,7 @@ defmodule Benchee.BenchmarkTest do
 
   test ".measure doesn't print out information about warmup (annoying)" do
     output = capture_io fn ->
-      %{config: %{time: 1000, warmup: 500}, jobs: []}
+      %{config: %{parallel: 1, time: 1000, warmup: 500}, jobs: []}
       |> Benchee.benchmark("noop", fn -> 0 end)
       |> Benchee.measure
     end
@@ -86,7 +87,7 @@ defmodule Benchee.BenchmarkTest do
 
   test ".measure never calls the function if warmup and time are 0" do
     output = capture_io fn ->
-      %{config: %{time: 0, warmup: 0}, jobs: [{"", fn -> IO.puts "called" end}]}
+      %{config: %{parallel: 1, time: 0, warmup: 0}, jobs: [{"", fn -> IO.puts "called" end}]}
       |> Benchmark.measure
     end
 

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -3,8 +3,8 @@ defmodule Benchee.StatistcsTest do
   doctest Benchee.Statistics
 
   test "statistics computes the statistics for all jobs correctly" do
-    suite = %{run_times: [{"Job 1", [600, 470, 170, 430, 300]},
-                          {"Job 2", [17, 15, 23, 7, 9, 13]}]}
+    suite = %{run_times: [{"Job 1", [[600, 470, 170, 430, 300]]},
+                          {"Job 2", [[17, 15, 23, 7, 9, 13]]}]}
 
     [{_, stats_1}, {_, stats_2}] = Benchee.Statistics.statistics suite
 


### PR DESCRIPTION
Hi!

I really like benchee but wanted to do some parallel benchmarking of certain code. So I added this in a fork, below shows how it works - maybe you'd like it as well.

It does change output of  Benchee.measure from:
`[{"bench", [1,2,3,4]}]`

into:
`[{"bench",[[1,2,3,4],[1,2,3,4]]}]`

Where the list is a list of results from separate processes each containing execution times of the passed function. I needed to do this to calc the ips. So had to modify Statistics.statistics for this as well...

regards,

Leon

--

When passing a flag parallel with value >1 then multiple processes
will be handled for benchmarking provided function.

For example:

```
iex> Benchee.run %{parallel: 5, time: 10},
                 [{"five", fn -> :timer.sleep(1000) end}]

Benchmarking name: five, parallel: 5, time: 10.0, warmup: 2.0...

Name           ips        average    deviation         median
five            4.98   1003737.24μs     (±0.10%)   1003672.00μs
```