### PR TITLE
Allow "roughly 10K" to include 12K

### DIFF
--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -155,7 +155,7 @@ defmodule BencheeTest do
     assert output =~ "Formatter two"
   end
 
-  @rough_10_milli_s "(9\\d{3}|10\\d{3}|11\\d{3})"
+  @rough_10_milli_s "((9|10|11|12)\\d{3})"
   test "formatters have full access to the suite data" do
     output = capture_io fn ->
       Benchee.run(%{


### PR DESCRIPTION
This test broke on my machine by reaching 12K for some runs. This commit allows for that, and simplifies the regex a bit.