### PR TITLE
Add unit scaling to Console formatter

### DIFF
--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -7,8 +7,6 @@ defmodule Benchee.Formatters.Console do
   alias Benchee.Statistics
   alias Benchee.Unit.{Count, Duration}
 
-  import Benchee.Unit, only: [float_precision: 1]
-
   @default_label_width 4 # Length of column header
   @ips_width 13
   @average_width 15
@@ -34,16 +32,17 @@ defmodule Benchee.Formatters.Console do
   iex> jobs = %{"My Job" => %{average: 200.0, ips: 5000.0, std_dev_ratio: 0.1, median: 190.0}}
   iex> Benchee.Formatters.Console.format(%{statistics: jobs, config: %{print: %{comparison: false}}})
   ["\nName             ips        average    deviation         median\n",
-  "My Job       5.00K      200.00 μs    (±10.00%)      190.00 μs"]
+  "My Job        5.00 K      200.00 μs    (±10.00%)      190.00 μs"]
 
   ```
 
   """
   def format(%{statistics: job_stats, config: config}) do
     sorted_stats = Statistics.sort(job_stats)
+    units = units(sorted_stats)
     label_width = label_width job_stats
-    [column_descriptors(label_width) | job_reports(sorted_stats, label_width)
-      ++ comparison_report(sorted_stats, label_width, config)]
+    [column_descriptors(label_width) | job_reports(sorted_stats, units, label_width)
+      ++ comparison_report(sorted_stats, units, label_width, config)]
     |> remove_last_blank_line
   end
 
@@ -63,8 +62,7 @@ defmodule Benchee.Formatters.Console do
     max_label_width + 1
   end
 
-  defp job_reports(jobs, label_width) do
-    units = units(jobs)
+  defp job_reports(jobs, units, label_width) do
     Enum.map(jobs, fn(job) -> format_job job, units, label_width end)
   end
 
@@ -78,7 +76,6 @@ defmodule Benchee.Formatters.Console do
       ips:      Count.best(collected_values.ips),
     }
   end
-
 
   defp format_job({name, %{average:       average,
                            ips:           ips,
@@ -110,35 +107,35 @@ defmodule Benchee.Formatters.Console do
     |> to_string
   end
 
-  defp comparison_report([_reference], _, _config) do
+  defp comparison_report([_reference], _, _, _config) do
     [] # No need for a comparison when only one benchmark was run
   end
-  defp comparison_report(_, _, %{console: %{comparison: false}}) do
+  defp comparison_report(_, _, _, %{console: %{comparison: false}}) do
     []
   end
-  defp comparison_report([reference | other_jobs], label_width, _config) do
+  defp comparison_report([reference | other_jobs], units, label_width, _config) do
     [
       comparison_descriptor,
-      reference_report(reference, label_width) |
-      comparisons(reference, label_width, other_jobs)
+      reference_report(reference, units, label_width) |
+      comparisons(reference, units, label_width, other_jobs)
     ]
   end
 
-  defp reference_report({name, %{ips: ips}}, label_width) do
-    "~*s~*.2f\n"
-    |> :io_lib.format([-label_width, name, @ips_width, ips])
+  defp reference_report({name, %{ips: ips}}, %{ips: ips_unit}, label_width) do
+    "~*s~*s\n"
+    |> :io_lib.format([-label_width, name, @ips_width, ips_out(ips, ips_unit)])
     |> to_string
   end
 
-  defp comparisons({_, reference_stats}, label_width, jobs_to_compare) do
+  defp comparisons({_, reference_stats}, units, label_width, jobs_to_compare) do
     Enum.map jobs_to_compare, fn(job = {_, job_stats}) ->
-      format_comparison(job, label_width, (reference_stats.ips / job_stats.ips))
+      format_comparison(job, units, label_width, (reference_stats.ips / job_stats.ips))
     end
   end
 
-  defp format_comparison({name, %{ips: ips}}, label_width, times_slower) do
-    "~*s~*.2f - ~.2fx slower\n"
-    |> :io_lib.format([-label_width, name, @ips_width, ips, times_slower])
+  defp format_comparison({name, %{ips: ips}}, %{ips: ips_unit}, label_width, times_slower) do
+    "~*s~*s - ~.2fx slower\n"
+    |> :io_lib.format([-label_width, name, @ips_width, ips_out(ips, ips_unit), times_slower])
     |> to_string
   end
 

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -100,11 +100,8 @@ defmodule Benchee.Formatters.Console do
     Count.format(Count.scale(ips, unit))
   end
 
-  defp run_time_out(average, _unit) do
-    # scaled_average = Duration.scale(average, unit)
-    "~.#{float_precision(average)}f~ts"
-    |> :io_lib.format([average, " μs"])
-    |> to_string
+  defp run_time_out(average, unit) do
+    Duration.format(Duration.scale(average, unit))
   end
 
   defp deviation_out(std_dev_ratio) do

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -69,16 +69,17 @@ defmodule Benchee.Formatters.Console do
   defp units(jobs) do
     # Produces a map like
     #   %{run_time: [12345, 15431, 13222], ips: [1, 2, 3]}
-    collected_values = jobs
-    |> Enum.flat_map(fn({_name, job}) -> Map.to_list(job) end)
-    # TODO: Simplify when dropping support for 1.2
-    # For compatibility with Elixir 1.2. In 1.3, the following group-reduce-map
-    # can b replaced by a single call to `group_by/3`
-    #   Enum.group_by(fn({measurement, _}) -> measurement end, fn({_, value}) -> value end)
-    |> Enum.group_by(fn({measurement, _unit}) -> measurement end)
-    |> Enum.reduce(%{}, fn({measurement, occurrences}, acc) ->
-      Map.put(acc, measurement, Enum.map(occurrences, fn({_meas, value}) -> value end))
-    end)
+    collected_values =
+      jobs
+      |> Enum.flat_map(fn({_name, job}) -> Map.to_list(job) end)
+      # TODO: Simplify when dropping support for 1.2
+      # For compatibility with Elixir 1.2. In 1.3, the following group-reduce-map
+      # can b replaced by a single call to `group_by/3`
+      #   Enum.group_by(fn({stat_name, _}) -> stat_name end, fn({_, value}) -> value end)
+      |> Enum.group_by(fn({stat_name, _value}) -> stat_name end)
+      |> Enum.reduce(%{}, fn({stat_name, occurrences}, acc) ->
+        Map.put(acc, stat_name, Enum.map(occurrences, fn({_stat_name, value}) -> value end))
+      end)
 
     %{
       run_time: Duration.best(collected_values.average),

--- a/lib/benchee/formatters/unit.ex
+++ b/lib/benchee/formatters/unit.ex
@@ -41,18 +41,13 @@ defmodule Benchee.Unit do
   """
   @callback separator :: String.t
 
-  def float_precision(float) when float < 0.01, do: 5
-  def float_precision(float) when float < 0.1, do: 4
-  def float_precision(float) when float < 0.2, do: 3
-  def float_precision(_float), do: 2
-
   # Common functions used by unit types
   defmodule Common do
     @moduledoc false
 
     def format({count, unit}, label, separator) do
       separator = separator(label, separator)
-      "~.#{Benchee.Unit.float_precision(count)}f~ts~ts"
+      "~.#{float_precision(count)}f~ts~ts"
       |> :io_lib.format([count, separator, label])
       |> to_string
     end
@@ -134,5 +129,10 @@ defmodule Benchee.Unit do
         _  -> separator
       end
     end
+
+    defp float_precision(float) when float < 0.01, do: 5
+    defp float_precision(float) when float < 0.1, do: 4
+    defp float_precision(float) when float < 0.2, do: 3
+    defp float_precision(_float), do: 2
   end
 end

--- a/lib/benchee/formatters/unit.ex
+++ b/lib/benchee/formatters/unit.ex
@@ -28,6 +28,12 @@ defmodule Benchee.Unit do
 
   @callback magnitude(unit) :: number
 
+  @doc """
+  A separator that should appear between a value and a unit label. For example,
+  a space: `5.67 M` or an empty string: `5.67M`
+  """
+  @callback separator :: String.t
+
   def float_precision(float) when float < 0.01, do: 5
   def float_precision(float) when float < 0.1, do: 4
   def float_precision(float) when float < 0.2, do: 3
@@ -37,10 +43,15 @@ defmodule Benchee.Unit do
   defmodule Common do
     @moduledoc false
 
-    def format({count, unit}, module) do
-      "~.#{Benchee.Unit.float_precision(count)}f~ts"
-      |> :io_lib.format([count, module.label(unit)])
+    def format({count, unit}, label, separator) do
+      separator = separator(label, separator)
+      "~.#{Benchee.Unit.float_precision(count)}f~ts~ts"
+      |> :io_lib.format([count, separator, label])
       |> to_string
+    end
+
+    def format({count, unit}, module) do
+      format({count, unit}, module.label(unit), module.separator)
     end
 
     def format(number, module) do
@@ -107,6 +118,14 @@ defmodule Benchee.Unit do
     end
     defp by_frequency_and_magnitude({_, frequency_a}, {_, frequency_b}, _module) do
       frequency_a > frequency_b
+    end
+
+    # Returns the separator, or an empty string if there isn't a label
+    defp separator(label, separator) do
+      case label do
+        "" -> ""
+        _  -> separator
+      end
     end
   end
 end

--- a/lib/benchee/formatters/unit.ex
+++ b/lib/benchee/formatters/unit.ex
@@ -20,6 +20,13 @@ defmodule Benchee.Unit do
   """
   @callback scale(number) :: scaled_number
 
+  @doc """
+  Scales a number in a domain's base unit to an equivalent value in the
+  specified unit. Results are a `{number, unit}` tuple. See
+  `Benchee.Unit.Count` and `Benchee.Unit.Duration` for examples
+  """
+  @callback scale(number, unit) :: scaled_number
+
   @callback format(number) :: String.t
 
   @callback best(list, options) :: unit

--- a/lib/benchee/formatters/unit/count.ex
+++ b/lib/benchee/formatters/unit/count.ex
@@ -90,4 +90,6 @@ defmodule Benchee.Unit.Count do
   def label(unit) do
     Common.label(@units, unit)
   end
+
+  def separator, do: " "
 end

--- a/lib/benchee/formatters/unit/count.ex
+++ b/lib/benchee/formatters/unit/count.ex
@@ -30,10 +30,49 @@ defmodule Benchee.Unit.Count do
       {0.0045, :one}
 
   """
-  def scale(count) when count >= @one_billion,  do: {count / @one_billion, :billion}
-  def scale(count) when count >= @one_million,  do: {count / @one_million, :million}
-  def scale(count) when count >= @one_thousand, do: {count / @one_thousand, :thousand}
-  def scale(count), do: {count, :one}
+  def scale(count) when count >= @one_billion do
+    scale(count, :billion)
+  end
+  def scale(count) when count >= @one_million do
+    scale(count, :million)
+  end
+  def scale(count) when count >= @one_thousand do
+    scale(count, :thousand)
+  end
+  def scale(count) do
+    scale(count, :one)
+  end
+
+  @doc """
+  Scales a value representing a count in ones into a specified unit
+
+  ## Examples
+
+    iex> Benchee.Unit.Count.scale(12345, :one)
+    {12345, :one}
+
+    iex> Benchee.Unit.Count.scale(12345, :thousand)
+    {12.345, :thousand}
+
+    iex> Benchee.Unit.Count.scale(12345, :billion)
+    {1.2345e-5, :billion}
+
+    iex> Benchee.Unit.Count.scale(12345, :million)
+    {0.012345, :million}
+
+  """
+  def scale(count, :billion) do
+    {count / @one_billion, :billion}
+  end
+  def scale(count, :million) do
+    {count / @one_million, :million}
+  end
+  def scale(count, :thousand) do
+    {count / @one_thousand, :thousand}
+  end
+  def scale(count, :one) do
+    {count, :one}
+  end
 
   def format(count) do
     Common.format(count, __MODULE__)

--- a/lib/benchee/formatters/unit/duration.ex
+++ b/lib/benchee/formatters/unit/duration.ex
@@ -79,13 +79,13 @@ defmodule Benchee.Unit.Duration do
 
   ## Examples
 
-    iex(3)> Benchee.Unit.Duration.scale(12345, :microsecond)
+    iex> Benchee.Unit.Duration.scale(12345, :microsecond)
     {12345, :microsecond}
 
-    iex(4)> Benchee.Unit.Duration.scale(12345, :millisecond)
+    iex> Benchee.Unit.Duration.scale(12345, :millisecond)
     {12.345, :millisecond}
 
-    iex(5)> Benchee.Unit.Duration.scale(12345, :minute)
+    iex> Benchee.Unit.Duration.scale(12345, :minute)
     {2.0575e-4, :minute}
 
   """

--- a/lib/benchee/formatters/unit/duration.ex
+++ b/lib/benchee/formatters/unit/duration.ex
@@ -121,4 +121,6 @@ defmodule Benchee.Unit.Duration do
   def magnitude(unit) do
     Common.magnitude(@units, unit)
   end
+
+  def separator, do: " "
 end

--- a/lib/benchee/formatters/unit/duration.ex
+++ b/lib/benchee/formatters/unit/duration.ex
@@ -48,29 +48,62 @@ defmodule Benchee.Unit.Duration do
 
   ## Examples
 
-      iex(3)> Benchee.Unit.Duration.scale(1)
+      iex> Benchee.Unit.Duration.scale(1)
       {1, :microsecond}
 
-      iex(5)> Benchee.Unit.Duration.scale(1_234)
+      iex> Benchee.Unit.Duration.scale(1_234)
       {1.234, :millisecond}
 
-      iex(8)> Benchee.Unit.Duration.scale(11_234_567_890.123)
+      iex> Benchee.Unit.Duration.scale(11_234_567_890.123)
       {3.1207133028119443, :hour}
 
   """
   def scale(duration) when duration >= @microseconds_per_hour do
-    {duration / @microseconds_per_hour, :hour}
+    scale(duration, :hour)
   end
   def scale(duration) when duration >= @microseconds_per_minute do
-    {duration / @microseconds_per_minute, :minute}
+    scale(duration, :minute)
   end
   def scale(duration) when duration >= @microseconds_per_second do
-    {duration / @microseconds_per_second, :second}
+    scale(duration, :second)
   end
   def scale(duration) when duration >= @microseconds_per_millisecond do
+    scale(duration, :millisecond)
+  end
+  def scale(duration) do
+    scale(duration, :microsecond)
+  end
+
+  @doc """
+  Scales a duration value in microseconds into a specified unit
+
+  ## Examples
+
+    iex(3)> Benchee.Unit.Duration.scale(12345, :microsecond)
+    {12345, :microsecond}
+
+    iex(4)> Benchee.Unit.Duration.scale(12345, :millisecond)
+    {12.345, :millisecond}
+
+    iex(5)> Benchee.Unit.Duration.scale(12345, :minute)
+    {2.0575e-4, :minute}
+
+  """
+  def scale(duration, :hour) do
+    {duration / @microseconds_per_hour, :hour}
+  end
+  def scale(duration, :minute) do
+    {duration / @microseconds_per_minute, :minute}
+  end
+  def scale(duration, :second) do
+    {duration / @microseconds_per_second, :second}
+  end
+  def scale(duration, :millisecond) do
     {duration / @microseconds_per_millisecond, :millisecond}
   end
-  def scale(duration), do: {duration, :microsecond}
+  def scale(duration, :microsecond) do
+    {duration, :microsecond}
+  end
 
   def format(count) do
     Common.format(count, __MODULE__)

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -23,7 +23,7 @@ defmodule Benchee.Formatters.ConsoleTest do
     assert output =~ ~r/First/
     assert output =~ ~r/Second/
     assert output =~ ~r/200/
-    assert output =~ ~r/5.00K/
+    assert output =~ ~r/5.00 K/
     assert output =~ ~r/10.00%/
     assert output =~ ~r/195.5/
   end
@@ -97,8 +97,8 @@ defmodule Benchee.Formatters.ConsoleTest do
       Console.format(%{statistics: jobs, config: @config})
 
     assert Regex.match? ~r/Comparison/, comp_header
-    assert Regex.match? ~r/^First\s+10.00K$/m, reference
-    assert Regex.match? ~r/^Second\s+5.00K\s+- 2.00x slower/, slower
+    assert Regex.match? ~r/^First\s+10.00 K$/m, reference
+    assert Regex.match? ~r/^Second\s+5.00 K\s+- 2.00x slower/, slower
   end
 
   test ".format can omit the comparisons" do
@@ -115,8 +115,8 @@ defmodule Benchee.Formatters.ConsoleTest do
                                         config: %{console: %{comparison: false}}})
 
     refute Regex.match? ~r/Comparison/i, output
-    refute Regex.match? ~r/^First\s+10.00K$/m, output
-    refute Regex.match? ~r/^Second\s+5.00K\s+- 2.00x slower/, output
+    refute Regex.match? ~r/^First\s+10.00 K$/m, output
+    refute Regex.match? ~r/^Second\s+5.00 K\s+- 2.00x slower/, output
   end
 
   test ".format adjusts the label width to longest name for comparisons" do
@@ -178,10 +178,10 @@ defmodule Benchee.Formatters.ConsoleTest do
     assert [_, result] = Console.format %{statistics: jobs, config: @config}
 
     refute result =~ ~r/\de\d/
-    assert result =~ "11.00K"
-    assert result =~ "12.00K"
+    assert result =~ "11.00 ms"
+    assert result =~ "12.00 K"
     assert result =~ "13000"
-    assert result =~ "140.00K"
+    assert result =~ "140.00 ms"
   end
 
   test ".format doesn't end in an empty line with multiple results" do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -210,7 +210,7 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     assert expected_width == column_width, """
 Expected column width of #{expected_width}, got #{column_width}
-line:   #{inspect String.trim(string)}
+line:   #{inspect String.strip(string)}
 column: #{inspect column}
 """
   end

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -181,7 +181,7 @@ defmodule Benchee.Formatters.ConsoleTest do
     assert result =~ "11.00 ms"
     assert result =~ "12.00 K"
     assert result =~ "13000"
-    assert result =~ "140.00"
+    assert result =~ "140.00 ms"
   end
 
   test ".format doesn't end in an empty line with multiple results" do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -23,8 +23,8 @@ defmodule Benchee.Formatters.ConsoleTest do
     assert output =~ ~r/First/
     assert output =~ ~r/Second/
     assert output =~ ~r/200/
-    assert output =~ ~r/5000/
-    assert output =~ ~r/10.+%/
+    assert output =~ ~r/5.00K/
+    assert output =~ ~r/10.00%/
     assert output =~ ~r/195.5/
   end
 
@@ -97,8 +97,8 @@ defmodule Benchee.Formatters.ConsoleTest do
       Console.format(%{statistics: jobs, config: @config})
 
     assert Regex.match? ~r/Comparison/, comp_header
-    assert Regex.match? ~r/^First\s+10000.00$/m, reference
-    assert Regex.match? ~r/^Second\s+5000.00\s+- 2.00x slower/, slower
+    assert Regex.match? ~r/^First\s+10.00K$/m, reference
+    assert Regex.match? ~r/^Second\s+5.00K\s+- 2.00x slower/, slower
   end
 
   test ".format can omit the comparisons" do
@@ -115,8 +115,8 @@ defmodule Benchee.Formatters.ConsoleTest do
                                         config: %{console: %{comparison: false}}})
 
     refute Regex.match? ~r/Comparison/i, output
-    refute Regex.match? ~r/^First\s+10000.00$/m, output
-    refute Regex.match? ~r/^Second\s+5000.00\s+- 2.00x slower/, output
+    refute Regex.match? ~r/^First\s+10.00K$/m, output
+    refute Regex.match? ~r/^Second\s+5.00K\s+- 2.00x slower/, output
   end
 
   test ".format adjusts the label width to longest name for comparisons" do
@@ -178,10 +178,10 @@ defmodule Benchee.Formatters.ConsoleTest do
     assert [_, result] = Console.format %{statistics: jobs, config: @config}
 
     refute result =~ ~r/\de\d/
-    assert result =~ "11000"
-    assert result =~ "12000"
+    assert result =~ "11.00K"
+    assert result =~ "12.00K"
     assert result =~ "13000"
-    assert result =~ "14000"
+    assert result =~ "140.00K"
   end
 
   test ".format doesn't end in an empty line with multiple results" do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -181,7 +181,7 @@ defmodule Benchee.Formatters.ConsoleTest do
     assert result =~ "11.00 ms"
     assert result =~ "12.00 K"
     assert result =~ "13000"
-    assert result =~ "140.00 ms"
+    assert result =~ "140.00"
   end
 
   test ".format doesn't end in an empty line with multiple results" do
@@ -203,10 +203,15 @@ defmodule Benchee.Formatters.ConsoleTest do
     # add 13 characters for the ips column, and an extra space between the columns
     expected_width = expected_width + 14
     n = Regex.escape name
-    regex = Regex.compile! "(#{n} +([0-9\.]+|ips))( |$)"
+    regex = Regex.compile! "(#{n} +([0-9\.]+( [[:alpha:]]+)?|ips))( |$)"
     assert Regex.match? regex, string
-    assert expected_width == Regex.run(regex, string, capture: :all_but_first)
-                             |> hd
-                             |> String.length
+    [column | _] = Regex.run(regex, string, capture: :all_but_first)
+    column_width = String.length(column)
+
+    assert expected_width == column_width, """
+Expected column width of #{expected_width}, got #{column_width}
+line:   #{inspect String.trim(string)}
+column: #{inspect column}
+"""
   end
 end

--- a/test/benchee/formatters/unit/count_test.exs
+++ b/test/benchee/formatters/unit/count_test.exs
@@ -56,11 +56,11 @@ defmodule Benchee.Unit.CountTest do
   end
 
   test ".format(1_000_000)" do
-    assert format(1_000_000) == "1.00M"
+    assert format(1_000_000) == "1.00 M"
   end
 
   test ".format(1_000.1234)" do
-    assert format(1_000.1234) == "1.00K"
+    assert format(1_000.1234) == "1.00 K"
   end
 
   test ".format(123.4)" do

--- a/test/benchee/formatters/unit/duration_test.exs
+++ b/test/benchee/formatters/unit/duration_test.exs
@@ -4,39 +4,39 @@ defmodule Benchee.Unit.DurationTest do
   doctest Benchee.Unit.Duration
 
   test ".format(98.7654321)" do
-    assert format(98.7654321) == "98.77μs"
+    assert format(98.7654321) == "98.77 μs"
   end
 
   test ".format(987.654321)" do
-    assert format(987.654321) == "987.65μs"
+    assert format(987.654321) == "987.65 μs"
   end
 
   test ".format(9_876.54321)" do
-    assert format(9_876.54321) == "9.88ms"
+    assert format(9_876.54321) == "9.88 ms"
   end
 
   test ".format(98_765.4321)" do
-    assert format(98_765.4321) == "98.77ms"
+    assert format(98_765.4321) == "98.77 ms"
   end
 
   test ".format(987_654.321)" do
-    assert format(987_654.321) == "987.65ms"
+    assert format(987_654.321) == "987.65 ms"
   end
 
   test ".format(9_876_543.21)" do
-    assert format(9_876_543.21) == "9.88s"
+    assert format(9_876_543.21) == "9.88 s"
   end
 
   test ".format(98_765_432.19)" do
-    assert format(98_765_432.19) == "1.65m"
+    assert format(98_765_432.19) == "1.65 m"
   end
 
   test ".format(987_654_321.9876)" do
-    assert format(987_654_321.9876) == "16.46m"
+    assert format(987_654_321.9876) == "16.46 m"
   end
 
   test ".format(9_876_543_219.8765)" do
-    assert format(9_876_543_219.8765) == "2.74h"
+    assert format(9_876_543_219.8765) == "2.74 h"
   end
 
   @list_with_mostly_milliseconds [1, 200, 3_000, 4_000, 500_000, 6_000_000, 77_000_000_000]

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -155,7 +155,7 @@ defmodule BencheeTest do
     assert output =~ "Formatter two"
   end
 
-  @rough_10_milli_s "((9|10|11|12)\\d{3})"
+  @rough_10_milli_s "((9|10|11|12|13)\\.\\d{2} ms)"
   test "formatters have full access to the suite data" do
     output = capture_io fn ->
       Benchee.run(%{
@@ -164,10 +164,10 @@ defmodule BencheeTest do
         custom:     "Custom value",
         formatters: [
           fn(suite) ->
-            IO.puts "Run time: #{List.last suite.run_times["Sleeps"]}"
+            IO.puts "Run time: #{List.last(suite.run_times["Sleeps"]) |> Benchee.Unit.Duration.format}"
           end,
           fn(suite) ->
-            IO.puts "Average: #{suite.statistics["Sleeps"].average}"
+            IO.puts "Average: #{suite.statistics["Sleeps"].average |> Benchee.Unit.Duration.format}"
           end,
           fn(suite) -> IO.puts suite.config.custom end
         ]
@@ -175,7 +175,7 @@ defmodule BencheeTest do
     end
 
     assert output =~ ~r/Run time: #{@rough_10_milli_s}$/m
-    assert output =~ ~r/Average: #{@rough_10_milli_s}\.\d+$/m
+    assert output =~ ~r/Average: #{@rough_10_milli_s}$/m
     assert output =~ "Custom value"
   end
 


### PR DESCRIPTION
Integrates unit scaling into the Console formatter (solution for #27)

Features:

- always scales results
- always uses "short" format, e.g. `M` for `Million`
- adds a space between the value and the unit label to match previous output, e.g. `10 μs`
- chooses the "best" unit for a column, and uses that unit for all values
- maintains hard-coded float precision
- adds the ability to scale a value to a specified unit
- adds an improved failure message for column width testing:

![image](https://cloud.githubusercontent.com/assets/908/18642028/b2273bac-7e64-11e6-8fa9-92dea2751a01.png)

Limitations:

- has no option for disabling scaling
- has no option for using a "long" label