### PR TITLE
Edits to unit scaling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ Benchee.run(%{time: 3}, %{
   "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten end})
 ```
 
-First configuration options are passed, the only options available so far are:
+First configuration options are passed:
 
 * `warmup` - the time in seconds for which a benchmark should be run without measuring times before real measurements start. This simulates a _"warm"_ running system. Defaults to 2.
 * `time` - the time in seconds for how long each individual benchmark should be run and measured. Defaults to 5.
 * `parallel` - each job will be executed in `parallel` number processes. Gives you more data in the same time, but also puts a load on the system interfering with benchmark results. For more on the pros and cons of parallel benchmarking [check the wiki](https://github.com/PragTob/benchee/wiki/Parallel-Benchmarking). Defaults to 1.
-* `formatters` - list of formatter function you'd like to run to output the benchmarking results of the suite when using `Benchee.run/2`. Functions need to accept one argument (which is the benchmarking suite with all data) and then use that to produce output. Used for plugins. Defaults to the builtin console formatter calling `Benche.Formatters.Console.output/1`.
+* `formatters` - list of formatter function you'd like to run to output the benchmarking results of the suite when using `Benchee.run/2`. Functions need to accept one argument (which is the benchmarking suite with all data) and then use that to produce output. Used for plugins. Defaults to the builtin console formatter calling `Benchee.Formatters.Console.output/1`.
 * `print`      - a map from atoms to `true` or `false` to configure if the output identified by the atom will be printed during the standard benchee benchmarking process. All options are enabled by default (true). Options are:
   * `:benchmarking`  - print when Benchee starts benchmarking a new job (Benchmarking name ..)
   * `:configuration` - a summary of configured benchmarking options including estimated total run time is printed before benchmarking starts
-  * `:fast_warning` - warnings are displayed if functions are executed too    fast leading to inaccurate measures
+  * `:fast_warning` - warnings are displayed if functions are executed too fast leading to inaccurate measures
 * `console` - options for the built-in console formatter. Like the `print` options they are also enabled by default:
   * `:comparison` - if the comparison of the different benchmarking jobs (x times slower than) is shown
-
+  * `:unit_scaling` - how to scale the units of formatted values. One of `:best` (default), `:largest`, `:smallest`, `:none`)
 
 
 Running this script produces an output like:
@@ -85,8 +85,8 @@ Benchmarking flat_map...
 Benchmarking map.flatten...
 
 Name                  ips        average    deviation         median
-map.flatten        989.80      1010.31μs    (±12.63%)       998.00μs
-flat_map           647.35      1544.75μs    (±10.54%)      1556.00μs
+map.flatten        989.80      1010.31ms    (±12.63%)       998.00ms
+flat_map           647.35      1544.75ms    (±10.54%)      1556.00ms
 
 Comparison:
 map.flatten        989.80

--- a/README.md
+++ b/README.md
@@ -59,15 +59,31 @@ First configuration options are passed:
 * `warmup` - the time in seconds for which a benchmark should be run without measuring times before real measurements start. This simulates a _"warm"_ running system. Defaults to 2.
 * `time` - the time in seconds for how long each individual benchmark should be run and measured. Defaults to 5.
 * `parallel` - each job will be executed in `parallel` number processes. Gives you more data in the same time, but also puts a load on the system interfering with benchmark results. For more on the pros and cons of parallel benchmarking [check the wiki](https://github.com/PragTob/benchee/wiki/Parallel-Benchmarking). Defaults to 1.
-* `formatters` - list of formatter function you'd like to run to output the benchmarking results of the suite when using `Benchee.run/2`. Functions need to accept one argument (which is the benchmarking suite with all data) and then use that to produce output. Used for plugins. Defaults to the builtin console formatter calling `Benchee.Formatters.Console.output/1`.
-* `print`      - a map from atoms to `true` or `false` to configure if the output identified by the atom will be printed during the standard benchee benchmarking process. All options are enabled by default (true). Options are:
+* `formatters` - list of formatter functions you'd like to run to output the benchmarking results of the suite when using `Benchee.run/2`. Functions need to accept one argument (which is the benchmarking suite with all data) and then use that to produce output. Used for plugins. Defaults to the builtin console formatter calling `Benchee.Formatters.Console.output/1`.
+* `print`      - a map from atoms to `true` or `false` to configure if the output identified by the atom will be printed during the standard Benchee benchmarking process. All options are enabled by default (true). Options are:
   * `:benchmarking`  - print when Benchee starts benchmarking a new job (Benchmarking name ..)
   * `:configuration` - a summary of configured benchmarking options including estimated total run time is printed before benchmarking starts
   * `:fast_warning` - warnings are displayed if functions are executed too fast leading to inaccurate measures
 * `console` - options for the built-in console formatter. Like the `print` options they are also enabled by default:
   * `:comparison` - if the comparison of the different benchmarking jobs (x times slower than) is shown
-  * `:unit_scaling` - how to scale the units of formatted values. One of `:best` (default), `:largest`, `:smallest`, `:none`)
+  * `:unit_scaling` - the strategy for choosing a unit for durations and
+  counts. When scaling a value, Benchee finds the "best fit" unit (the
+  largest unit for which the result is at least 1). For example, 1_200_000
+  scales to `1.2 M`, while `800_000` scales to `800 K`. The `unit_scaling`
+  strategy determines how Benchee chooses the best fit unit for an entire
+  list of values, when the individual values in the list may have different
+  best fit units.
 
+  There are four strategies, defaulting to `best`:
+      * `:best`    - the most frequent best fit unit will be used, a tie
+      will result in the larger unit being selected.
+      * `largest`  - the largest best fit unit will be used (i.e. thousand
+      and seconds if values are large enough).
+      * `smallest` - the smallest best fit unit will be used (i.e.
+      millisecond and one)
+      * `none`     - no unit scaling will occur. Durations will be displayed
+      in microseconds, and counts will be displayed in ones (this is
+      equivalent to the behaviour Benchee had pre 0.5.0)
 
 Running this script produces an output like:
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Benchmarking flat_map...
 Benchmarking map.flatten...
 
 Name                  ips        average    deviation         median
-map.flatten        989.80      1010.31ms    (±12.63%)       998.00ms
-flat_map           647.35      1544.75ms    (±10.54%)      1556.00ms
+map.flatten        989.80        1.01 ms    (±12.63%)        0.99 ms
+flat_map           647.35        1.54 ms    (±10.54%)        1.56 ms
 
 Comparison:
 map.flatten        989.80

--- a/README.md
+++ b/README.md
@@ -72,18 +72,16 @@ First configuration options are passed:
   scales to `1.2 M`, while `800_000` scales to `800 K`. The `unit_scaling`
   strategy determines how Benchee chooses the best fit unit for an entire
   list of values, when the individual values in the list may have different
-  best fit units.
-
-  There are four strategies, defaulting to `best`:
-      * `:best`    - the most frequent best fit unit will be used, a tie
-      will result in the larger unit being selected.
-      * `largest`  - the largest best fit unit will be used (i.e. thousand
-      and seconds if values are large enough).
-      * `smallest` - the smallest best fit unit will be used (i.e.
-      millisecond and one)
-      * `none`     - no unit scaling will occur. Durations will be displayed
-      in microseconds, and counts will be displayed in ones (this is
-      equivalent to the behaviour Benchee had pre 0.5.0)
+  best fit units. There are four strategies, defaulting to `:best`:
+    * `:best`    - the most frequent best fit unit will be used, a tie will
+    result in the larger unit being selected.
+    * `:largest`  - the largest best fit unit will be used (i.e. thousand
+    and seconds if values are large enough)
+    * `:smallest` - the smallest best fit unit will be used (i.e. millisecond
+    and one)
+    * `:none`     - no unit scaling will occur. Durations will be displayed in
+    microseconds, and counts will be displayed in ones (this is equivalent to
+    the behaviour Benchee had pre 0.5.0)
 
 Running this script produces an output like:
 

--- a/lib/benchee/config.ex
+++ b/lib/benchee/config.ex
@@ -46,14 +46,14 @@ defmodule Benchee.Config do
       list of values, when the individual values in the list may have different
       best fit units.
 
-      There are four strategies, defaulting to `best`:
-          * `:best`    - the most frequent best fit unit will be used, a tie
+      There are four strategies, defaulting to `:best`:
+          * `:best`     - the most frequent best fit unit will be used, a tie
           will result in the larger unit being selected.
-          * `largest`  - the largest best fit unit will be used (i.e. thousand
+          * `:largest`  - the largest best fit unit will be used (i.e. thousand
           and seconds if values are large enough).
-          * `smallest` - the smallest best fit unit will be used (i.e.
+          * `:smallest` - the smallest best fit unit will be used (i.e.
           millisecond and one)
-          * `none`     - no unit scaling will occur. Durations will be displayed
+          * `:none`     - no unit scaling will occur. Durations will be displayed
           in microseconds, and counts will be displayed in ones (this is
           equivalent to the behaviour Benchee had pre 0.5.0)
 

--- a/lib/benchee/config.ex
+++ b/lib/benchee/config.ex
@@ -55,7 +55,7 @@ defmodule Benchee.Config do
           millisecond and one)
           * `none`     - no unit scaling will occur. Durations will be displayed
           in microseconds, and counts will be displayed in ones (this is
-          equivalent to the behaviour benchee had pre 0.5.0)
+          equivalent to the behaviour Benchee had pre 0.5.0)
 
   ## Examples
 

--- a/lib/benchee/config.ex
+++ b/lib/benchee/config.ex
@@ -6,9 +6,10 @@ defmodule Benchee.Config do
   alias Benchee.Time
 
   @doc """
-  Returns the initial benchmark configuration for Benchee, composed of defauls
+  Returns the initial benchmark configuration for Benchee, composed of defaults
   and an optional custom configuration.
-  Configuration times are given in seconds, but are converted to microseconds.
+  Configuration times are given in seconds, but are converted to microseconds
+  internally.
 
   Possible options:
 
@@ -19,11 +20,11 @@ defmodule Benchee.Config do
     * `parallel`   - each job will be executed in `parallel` number processes.
     Gives you more data in the same time, but also puts a load on the system
     interfering with benchmark results. Defaults to 1.
-    * `formatters` - list of formatter function you'd like to run to output the
+    * `formatters` - list of formatter functions you'd like to run to output the
     benchmarking results of the suite when using `Benchee.run/2`. Functions need
     to accept one argument (which is the benchmarking suite with all data) and
     then use that to produce output. Used for plugins. Defaults to the builtin
-    console formatter calling `Benche.Formatters.Console.output/1`.
+    console formatter calling `Benchee.Formatters.Console.output/1`.
     * `print`      - a map from atoms to `true` or `false` to configure if the
     output identified by the atom will be printed. All options are enabled by
     default (true). Options are:
@@ -31,30 +32,30 @@ defmodule Benchee.Config do
       (Benchmarking name ..)
       * `:configuration` - a summary of configured benchmarking options
       including estimated total run time is printed before benchmarking starts
-      * `:fast_warning`   - warnings are displayed if functions are executed
+      * `:fast_warning`  - warnings are displayed if functions are executed
       too fast leading to inaccurate measures
     * `console` - options for the built-in console formatter. Like the
     `print` options the boolean options are also enabled by default:
       * `:comparison`   - if the comparison of the different benchmarking jobs
       (x times slower than) is shown (true/false)
-      * `:unit_scaling` - which strategy should be used to scale the units in
-      the output. When the documentation says "best fit unit" what is meant is
-      the unit in which the duration/count can be represented so that it is the
-      largest unit that can represent teh value and be at least 1. E.g.
-      1_200_000 will be scalled to `1.2 M` while `800_000` is scaled to
-      `800 K`. Which of all those "best fit" units will be selected to scale
-      all results to that unit is a matter of the strategy. There are four
-      different strategies defaulting to `:best`:
+      * `:unit_scaling` - the strategy for choosing a unit for durations and
+      counts. When scaling a value, Benchee finds the "best fit" unit (the
+      largest unit for which the result is at least 1). For example, 1_200_000
+      scales to `1.2 M`, while `800_000` scales to `800 K`. The `unit_scaling`
+      strategy determines how Benchee chooses the best fit unit for an entire
+      list of values, when the individual values in the list may have different
+      best fit units.
+
+      There are four strategies, defaulting to `best`:
           * `:best`    - the most frequent best fit unit will be used, a tie
           will result in the larger unit being selected.
-          * `largest`  - the largest best fit unit will be used (i.e. Thousand
+          * `largest`  - the largest best fit unit will be used (i.e. thousand
           and seconds if values are large enough).
           * `smallest` - the smallest best fit unit will be used (i.e.
           millisecond and one)
-          * `none`     - no unit scaling will occur, e.g. the units will be the
-          base units microseconds and one (this is equivalent to the behaviour
-          benchee had pre 0.5.0)
-
+          * `none`     - no unit scaling will occur. Durations will be displayed
+          in microseconds, and counts will be displayed in ones (this is
+          equivalent to the behaviour benchee had pre 0.5.0)
 
   ## Examples
 

--- a/lib/benchee/config.ex
+++ b/lib/benchee/config.ex
@@ -44,9 +44,7 @@ defmodule Benchee.Config do
       scales to `1.2 M`, while `800_000` scales to `800 K`. The `unit_scaling`
       strategy determines how Benchee chooses the best fit unit for an entire
       list of values, when the individual values in the list may have different
-      best fit units.
-
-      There are four strategies, defaulting to `:best`:
+      best fit units. There are four strategies, defaulting to `:best`:
           * `:best`     - the most frequent best fit unit will be used, a tie
           will result in the larger unit being selected.
           * `:largest`  - the largest best fit unit will be used (i.e. thousand


### PR DESCRIPTION
- edits for readability, typos in Benchee.Config
- add unit_scaling option summary to README, and update the sample
  output to reflect default scaling to ms