### PR TITLE
Use Unit struct, and hang Unit functionality there

### DIFF
--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -3,7 +3,7 @@ defmodule Benchee.Conversion.Count do
   Unit scaling for counts, such that 1000000 can be converted to 1 Million.
   """
 
-  alias Benchee.Conversion.{Format, Scale}
+  alias Benchee.Conversion.{Format, Scale, Unit}
 
   @behaviour Scale
   @behaviour Format
@@ -13,10 +13,26 @@ defmodule Benchee.Conversion.Count do
   @one_thousand 1_000
 
   @units %{
-    billion:  %{magnitude: @one_billion, short: "B", long: "Billion"},
-    million:  %{magnitude: @one_million, short: "M", long: "Million"},
-    thousand: %{magnitude: @one_thousand, short: "K", long: "Thousand"},
-    one:      %{magnitude: 1, short: "", long: ""},
+    billion:  %Unit{
+                magnitude: @one_billion,
+                short: "B",
+                long: "Billion"
+              },
+    million:  %Unit{
+                magnitude: @one_million,
+                short: "M",
+                long: "Million"
+              },
+    thousand: %Unit{
+                magnitude: @one_thousand,
+                short: "K",
+                long: "Thousand"
+              },
+    one:      %Unit{
+                magnitude: 1,
+                short: "",
+                long: ""
+              },
   }
 
   @doc """
@@ -119,7 +135,7 @@ defmodule Benchee.Conversion.Count do
       1
   """
   def magnitude(unit) do
-    Scale.magnitude(@units, unit)
+    Unit.magnitude(@units, unit)
   end
 
   @doc """

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -36,6 +36,11 @@ defmodule Benchee.Conversion.Count do
   }
 
   @doc """
+  Units of count, in powers of 1_000: :one, :thousand, :million, :billion
+  """
+  def units, do: @units
+
+  @doc """
   Scales a value representing a count in ones into a larger unit if appropriate
 
   ## Examples
@@ -124,21 +129,6 @@ defmodule Benchee.Conversion.Count do
   end
 
   @doc """
-  The magnitude of the specified unit, as a number
-
-  ## Examples
-
-      iex> Benchee.Conversion.Count.magnitude(:million)
-      1000000
-
-      iex> Benchee.Conversion.Count.magnitude(:one)
-      1
-  """
-  def magnitude(unit) do
-    Unit.magnitude(@units, unit)
-  end
-
-  @doc """
   The raw count, unscaled.
 
   ## Examples
@@ -166,21 +156,6 @@ defmodule Benchee.Conversion.Count do
   """
   def format(count) do
     Format.format(count, __MODULE__)
-  end
-
-  @doc """
-  The label for the specified unit, as a string
-
-  ## Examples
-
-      iex> Benchee.Conversion.Count.label(:million)
-      "M"
-
-      iex> Benchee.Conversion.Count.label(:one)
-      ""
-  """
-  def label(unit) do
-    Format.label(@units, unit)
   end
 
   @doc """

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -157,10 +157,4 @@ defmodule Benchee.Conversion.Count do
   def format(count) do
     Format.format(count, __MODULE__)
   end
-
-  @doc """
-  A string that appears between a value and unit label when formatted. For
-  this module, a space
-  """
-  def separator, do: " "
 end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -203,10 +203,4 @@ defmodule Benchee.Conversion.Duration do
   def format(count) do
     Format.format(count, __MODULE__)
   end
-
-  @doc """
-  A string that appears between a value and unit label when formatted. For
-  this module, a space
-  """
-  def separator, do: " "
 end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -47,7 +47,7 @@ defmodule Benchee.Conversion.Duration do
   @doc """
   Units of duration: :microsecond, :millisecond, :second, :minute, :hour
   """
-  def units(), do: @units
+  def units, do: @units
 
   @doc """
   Scales a duration value in microseconds into a larger unit if appropriate

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -3,7 +3,7 @@ defmodule Benchee.Conversion.Duration do
   Unit scaling for duration converting from microseconds to minutes and others.
   """
 
-  alias Benchee.Conversion.{Format, Scale}
+  alias Benchee.Conversion.{Format, Scale, Unit}
 
   @behaviour Scale
   @behaviour Format
@@ -17,27 +17,27 @@ defmodule Benchee.Conversion.Duration do
   @microseconds_per_hour @microseconds_per_minute * @minutes_per_hour
 
   @units %{
-    hour:        %{
+    hour:        %Unit{
                     magnitude: @microseconds_per_hour,
                     short:     "h",
                     long:      "Hours"
                   },
-    minute:      %{
+    minute:      %Unit{
                     magnitude: @microseconds_per_minute,
                     short:     "m",
                     long: "Minutes"
                   },
-    second:      %{
+    second:      %Unit{
                     magnitude: @microseconds_per_second,
                     short:     "s",
                     long:      "Seconds"
                   },
-    millisecond: %{
+    millisecond: %Unit{
                     magnitude: @microseconds_per_millisecond,
                     short:     "ms",
                     long:      "Milliseconds"
                   },
-    microsecond: %{
+    microsecond: %Unit{
                     magnitude: 1,
                     short:     "μs",
                     long: "Microseconds"
@@ -180,7 +180,7 @@ defmodule Benchee.Conversion.Duration do
       1
   """
   def magnitude(unit) do
-    Scale.magnitude(@units, unit)
+    Unit.magnitude(@units, unit)
   end
 
   @doc """

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -21,28 +21,33 @@ defmodule Benchee.Conversion.Duration do
                     magnitude: @microseconds_per_hour,
                     short:     "h",
                     long:      "Hours"
-                  },
+                 },
     minute:      %Unit{
                     magnitude: @microseconds_per_minute,
                     short:     "m",
                     long: "Minutes"
-                  },
+                 },
     second:      %Unit{
                     magnitude: @microseconds_per_second,
                     short:     "s",
                     long:      "Seconds"
-                  },
+                 },
     millisecond: %Unit{
                     magnitude: @microseconds_per_millisecond,
                     short:     "ms",
                     long:      "Milliseconds"
-                  },
+                 },
     microsecond: %Unit{
                     magnitude: 1,
                     short:     "μs",
                     long: "Microseconds"
-                  }
+                 }
   }
+
+  @doc """
+  Units of duration: :microsecond, :millisecond, :second, :minute, :hour
+  """
+  def units(), do: @units
 
   @doc """
   Scales a duration value in microseconds into a larger unit if appropriate
@@ -169,21 +174,6 @@ defmodule Benchee.Conversion.Duration do
   end
 
   @doc """
-  The magnitude of the specified unit, as a number
-
-  ## Examples
-
-      iex> Benchee.Conversion.Duration.magnitude(:millisecond)
-      1000
-
-      iex> Benchee.Conversion.Duration.magnitude(:microsecond)
-      1
-  """
-  def magnitude(unit) do
-    Unit.magnitude(@units, unit)
-  end
-
-  @doc """
   The most basic unit in which measurements occur, microseconds.
 
   ## Examples
@@ -212,21 +202,6 @@ defmodule Benchee.Conversion.Duration do
   """
   def format(count) do
     Format.format(count, __MODULE__)
-  end
-
-  @doc """
-  The label for the specified unit, as a string
-
-  ## Examples
-
-      iex> Benchee.Conversion.Duration.label(:millisecond)
-      "ms"
-
-      iex> Benchee.Conversion.Duration.label(:microsecond)
-      "μs"
-  """
-  def label(unit) do
-    Format.label(@units, unit)
   end
 
   @doc """

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -27,22 +27,26 @@ defmodule Benchee.Conversion.Format do
   end
 
   @doc """
-  Formats a unit value in the domain described by `module`. The specified module
-  should provide a `units/0` function that returns a Map of
-  { :unit_name => `Benchee.Conversion.Unit` }. Additionally, `module` may
-  specify a `separator/0` function, which provides a custom separator string
-  that will appear between the value and label in the formatted output. If no
-  `separator/0` function exists, the default separator (a single space) will
-  be used.
-    """
+  Formats a unit value in the domain described by `module`. The module should
+  provide a `units/0` function that returns a Map like
+
+      %{ :unit_name => %Benchee.Conversion.Unit{ ... } }
+
+  Additionally, `module` may specify a `separator/0` function, which provides a
+  custom separator string that will appear between the value and label in the
+  formatted output. If no `separator/0` function exists, the default separator
+  (a single space) will be used.
+  """
   def format({count, unit}, module) do
     format({count, unit}, label(module, unit), separator(module))
   end
 
   @doc """
-  Scales a number to the most appropriate unit, and formats the scaled value
-  with the label and separator supplied by `module`. The
-  specified module should provide `label/1` and `separator/0` functions
+  Scales a number to the most appropriate unit as defined in `module`, and
+  formats the scaled value with a label. The module should provide a `units/0`
+  function that returns a Map like
+
+      %{ :unit_name => %Benchee.Conversion.Unit{ ... } }
   """
   def format(number, module) do
     number
@@ -50,7 +54,7 @@ defmodule Benchee.Conversion.Format do
     |> format(module)
   end
 
-  # Returns the separator defined in `module`, or the default, a space
+  # Returns the separator defined in `module.separator/0`, or the default, a space
   defp separator(module) do
     case function_exported?(module, :separator, 0) do
       true  -> module.separator()

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -19,7 +19,7 @@ defmodule Benchee.Conversion.Format do
   @doc """
   Formats a unit value with specified label and separator
   """
-  def format({count, _unit}, label, separator) do
+  def format(count, label, separator) do
     separator = separator(label, separator)
     "~.#{float_precision(count)}f~ts~ts"
     |> :io_lib.format([count, separator, label])
@@ -38,7 +38,7 @@ defmodule Benchee.Conversion.Format do
   (a single space) will be used.
   """
   def format({count, unit}, module) do
-    format({count, unit}, label(module, unit), separator(module))
+    format(count, label(module, unit), separator(module))
   end
 
   @doc """

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -6,17 +6,13 @@ defmodule Benchee.Conversion.Format do
   See `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
   """
 
+  alias Benchee.Conversion.Unit
+
   @doc """
   Formats a number as a string, with a unit label. See `Benchee.Conversion.Count`
   and `Benchee.Conversion.Duration` for examples
   """
   @callback format(number) :: String.t
-
-  @doc """
-  The label for a given unit, as a String.  See `Benchee.Conversion.Count`
-  and `Benchee.Conversion.Duration` for examples
-  """
-  @callback label(Benchee.Conversion.Scale.unit) :: String.t
 
   @doc """
   A string that appears between a value and a unit label when formatted as a
@@ -41,7 +37,7 @@ defmodule Benchee.Conversion.Format do
   specified module should provide `label/1` and `separator/0` functions
   """
   def format({count, unit}, module) do
-    format({count, unit}, module.label(unit), module.separator)
+    format({count, unit}, label(module, unit), module.separator)
   end
 
   @doc """
@@ -55,18 +51,14 @@ defmodule Benchee.Conversion.Format do
     |> format(module)
   end
 
-  @doc """
-  Fetches a label from a map of units
-  """
-  def label(units, unit) do
-    units
-    |> Map.fetch!(unit)
-    |> Map.fetch!(:short)
-  end
-
   # Returns the separator, or an empty string if there isn't a label
   defp separator(label, _separator) when label == "" or label == nil, do: ""
   defp separator(_label, separator), do: separator
+
+  # Fetches the label for the given unit
+  defp label(module, unit) do
+    Unit.label(module, unit)
+  end
 
   defp float_precision(float) when float < 0.01, do: 5
   defp float_precision(float) when float < 0.1, do: 4

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -37,8 +37,11 @@ defmodule Benchee.Conversion.Format do
   formatted output. If no `separator/0` function exists, the default separator
   (a single space) will be used.
   """
-  def format({count, unit}, module) do
-    format(count, label(module, unit), separator(module))
+  def format({count, unit = %Unit{}}, module) do
+    format(count, label(unit), separator(module))
+  end
+  def format({count, unit_atom}, module) do
+    format({count, module.unit_for(unit_atom)}, module)
   end
 
   @doc """
@@ -67,8 +70,8 @@ defmodule Benchee.Conversion.Format do
   defp separator(_label, separator), do: separator
 
   # Fetches the label for the given unit
-  defp label(module, unit) do
-    Unit.label(module, unit)
+  defp label(%Unit{label: label}) do
+    label
   end
 
   defp float_precision(float) when float < 0.01, do: 5

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -49,15 +49,6 @@ defmodule Benchee.Conversion.Scale do
   # Generic scaling functions
 
   @doc """
-  Fetches a unit's magnitude from a map of units
-  """
-  def magnitude(units, unit) do
-    units
-    |> Map.fetch!(unit)
-    |> Map.fetch!(:magnitude)
-  end
-
-  @doc """
   Given a `list` of number values and a `module` describing the domain of the
   values (e.g. Duration, Count), finds the "best fit" unit for the list as a
   whole.

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -6,6 +6,8 @@ defmodule Benchee.Conversion.Scale do
   See `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
   """
 
+  alias Benchee.Conversion.Unit
+
   @type unit :: atom
   @type scaled_number :: {number, unit}
 
@@ -33,12 +35,6 @@ defmodule Benchee.Conversion.Scale do
   most common units.
   """
   @callback best(list, options) :: unit
-
-  @doc """
-  The magnitude of a unit, as a number.  See `Benchee.Conversion.Count`
-  and `Benchee.Conversion.Duration` for examples
-  """
-  @callback magnitude(unit) :: number
 
   @doc """
   Returns the base_unit in which Benchee takes its measurements, which in
@@ -105,14 +101,14 @@ defmodule Benchee.Conversion.Scale do
   defp smallest_unit(list, module) do
     list
     |> Enum.map(fn n -> scale_unit(n, module) end)
-    |> Enum.min_by(&module.magnitude/1)
+    |> Enum.min_by(fn unit -> magnitude(module, unit) end)
   end
 
   # Finds the largest unit in the list
   defp largest_unit(list, module) do
     list
     |> Enum.map(fn n -> scale_unit(n, module) end)
-    |> Enum.max_by(&module.magnitude/1)
+    |> Enum.max_by(fn unit -> magnitude(module, unit) end)
   end
 
   defp scale_unit(count, module) do
@@ -120,10 +116,15 @@ defmodule Benchee.Conversion.Scale do
     unit
   end
 
+  # Fetches the magnitude for the given unit
+  defp magnitude(module, unit) do
+    Unit.magnitude(module, unit)
+  end
+
   # Sorts two elements first by total, then by magnitude of the unit in case
   # of tie
   defp by_frequency_and_magnitude({unit_a, frequency}, {unit_b, frequency}, module) do
-    module.magnitude(unit_a) > module.magnitude(unit_b)
+    magnitude(module, unit_a) > magnitude(module, unit_b)
   end
   defp by_frequency_and_magnitude({_, frequency_a}, {_, frequency_b}, _module) do
     frequency_a > frequency_b

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -8,7 +8,9 @@ defmodule Benchee.Conversion.Scale do
 
   alias Benchee.Conversion.Unit
 
-  @type unit :: atom
+  @type unit :: Unit.t
+  @type unit_atom :: atom
+  @type any_unit :: unit | unit_atom
   @type scaled_number :: {number, unit}
 
   # In 1.3, this could be declared as `keyword`, but use a custom type so it
@@ -27,7 +29,7 @@ defmodule Benchee.Conversion.Scale do
   specified unit. Results are a `{number, unit}` tuple. See
   `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
   """
-  @callback scale(number, unit) :: number
+  @callback scale(number, any_unit) :: number
 
   @doc """
   Finds the best fit unit for a list of numbers in a domain's base unit.
@@ -42,7 +44,50 @@ defmodule Benchee.Conversion.Scale do
   """
   @callback base_unit :: unit
 
+  @doc """
+  Given the atom representation of a unit (`:hour`) return the appropriate
+  `Benchee.Conversion.Unit` struct.
+  """
+  @callback unit_for(unit_atom) :: unit
+
   # Generic scaling functions
+
+  @doc """
+  Used internally by implemented units to handle their scaling with units and
+  without.
+
+  ## Examples
+
+      iex> Benchee.Conversion.Scale.scale(12345, :thousand, Benchee.Conversion.Count)
+      12.345
+  """
+  def scale(value, unit = %Unit{}, _module) do
+    scale(value, unit)
+  end
+  def scale(value, unit_atom, module) do
+    scale value, module.unit_for(unit_atom)
+  end
+
+  @doc """
+  Used internally for scaling but only supports scaling with actual units.
+
+  ## Examples
+
+      iex> unit = %Benchee.Conversion.Unit{magnitude: 1000}
+      iex> Benchee.Conversion.Scale.scale 12345, unit
+      12.345
+  """
+  def scale(value, %Unit{magnitude: magnitude}) do
+    value / magnitude
+  end
+
+  @doc """
+  Lookup a unit by its `atom` presentation for the representation of supported
+  units. Used by `Benchee.Conversion.Duration` and `Benchee.Conversion.Count`.
+  """
+  def unit_for(units, unit) do
+    Map.fetch! units, unit
+  end
 
   @doc """
   Given a `list` of number values and a `module` describing the domain of the
@@ -65,15 +110,15 @@ defmodule Benchee.Conversion.Scale do
   ## Examples
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best)
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
       :thousand
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :smallest)
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :smallest).name
       :one
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :largest)
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :largest).name
       :million
   """
   def best_unit(list, module, opts) do
@@ -92,7 +137,7 @@ defmodule Benchee.Conversion.Scale do
     |> Enum.map(fn n -> scale_unit(n, module) end)
     |> Enum.group_by(fn unit -> unit end)
     |> Enum.map(fn {unit, occurrences} -> {unit, length(occurrences)} end)
-    |> Enum.sort(fn unit, freq -> by_frequency_and_magnitude(unit, freq, module) end)
+    |> Enum.sort(fn unit, freq -> by_frequency_and_magnitude(unit, freq) end)
     |> hd
     |> elem(0)
   end
@@ -101,14 +146,14 @@ defmodule Benchee.Conversion.Scale do
   defp smallest_unit(list, module) do
     list
     |> Enum.map(fn n -> scale_unit(n, module) end)
-    |> Enum.min_by(fn unit -> magnitude(module, unit) end)
+    |> Enum.min_by(fn unit -> magnitude(unit) end)
   end
 
   # Finds the largest unit in the list
   defp largest_unit(list, module) do
     list
     |> Enum.map(fn n -> scale_unit(n, module) end)
-    |> Enum.max_by(fn unit -> magnitude(module, unit) end)
+    |> Enum.max_by(fn unit -> magnitude(unit) end)
   end
 
   defp scale_unit(count, module) do
@@ -117,16 +162,16 @@ defmodule Benchee.Conversion.Scale do
   end
 
   # Fetches the magnitude for the given unit
-  defp magnitude(module, unit) do
-    Unit.magnitude(module, unit)
+  defp magnitude(%Unit{magnitude: magnitude}) do
+    magnitude
   end
 
   # Sorts two elements first by total, then by magnitude of the unit in case
   # of tie
-  defp by_frequency_and_magnitude({unit_a, frequency}, {unit_b, frequency}, module) do
-    magnitude(module, unit_a) > magnitude(module, unit_b)
+  defp by_frequency_and_magnitude({unit_a, frequency}, {unit_b, frequency}) do
+    magnitude(unit_a) > magnitude(unit_b)
   end
-  defp by_frequency_and_magnitude({_, frequency_a}, {_, frequency_b}, _module) do
+  defp by_frequency_and_magnitude({_, frequency_a}, {_, frequency_b}) do
     frequency_a > frequency_b
   end
 end

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -1,57 +1,8 @@
 defmodule Benchee.Conversion.Unit do
-  defstruct [:magnitude, :short, :long]
+  defstruct [:name, :magnitude, :label, :long]
+  @type t :: %Benchee.Conversion.Unit{name:      atom,
+                                      magnitude: non_neg_integer,
+                                      label:     String.t,
+                                      long:      String.t}
 
-  @doc """
-  The magnitude of the given unit. Requires that `module` implements `units/0`,
-  and that `unit` is one of `module`'s units
-
-  ## Examples
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Duration, :millisecond)
-      1000
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Duration, :microsecond)
-      1
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Count, :million)
-      1000000
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Count, :one)
-      1
-
-
-  """
-  def magnitude(module, unit) do
-    fetch_nested_unit_field(module, unit, :magnitude)
-  end
-
-  @doc """
-  The label for the given unit. Requires that `module` implements `units/0`,
-  and that `unit` is one of `module`'s units
-
-  ## Examples
-
-      iex> Benchee.Conversion.Unit.label(Benchee.Conversion.Count, :million)
-      "M"
-
-      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Count, :one)
-      ""
-
-      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Duration, :millisecond)
-      "ms"
-
-      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Duration, :microsecond)
-      "μs"
-
-  """
-  def label(module, unit) do
-    fetch_nested_unit_field(module, unit, :short)
-  end
-
-  # Fetches the value of `field` from the `unit` in module's Map of units, `units/0`
-  defp fetch_nested_unit_field(module, unit, field) do
-    module.units()
-    |> Map.fetch!(unit)
-    |> Map.fetch!(field)
-  end
 end

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -1,14 +1,57 @@
 defmodule Benchee.Conversion.Unit do
   defstruct [:magnitude, :short, :long]
 
-@doc """
-Fetches a unit's magnitude from a map of units
-"""
-def magnitude(units, unit) do
-  units
-  |> Map.fetch!(unit)
-  |> Map.fetch!(:magnitude)
-end
+  @doc """
+  The magnitude of the given unit. Requires that `module` implements `units/0`,
+  and that `unit` is one of `module`'s units
+
+  ## Examples
+
+      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Duration, :millisecond)
+      1000
+
+      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Duration, :microsecond)
+      1
+
+      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Count, :million)
+      1000000
+
+      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Count, :one)
+      1
 
 
+  """
+  def magnitude(module, unit) do
+    fetch_nested_unit_field(module, unit, :magnitude)
+  end
+
+  @doc """
+  The label for the given unit. Requires that `module` implements `units/0`,
+  and that `unit` is one of `module`'s units
+
+  ## Examples
+
+      iex> Benchee.Conversion.Unit.label(Benchee.Conversion.Count, :million)
+      "M"
+
+      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Count, :one)
+      ""
+
+      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Duration, :millisecond)
+      "ms"
+
+      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Duration, :microsecond)
+      "μs"
+
+  """
+  def label(module, unit) do
+    fetch_nested_unit_field(module, unit, :short)
+  end
+
+  # Fetches the value of `field` from the `unit` in module's Map of units, `units/0`
+  defp fetch_nested_unit_field(module, unit, field) do
+    module.units()
+    |> Map.fetch!(unit)
+    |> Map.fetch!(field)
+  end
 end

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -1,0 +1,14 @@
+defmodule Benchee.Conversion.Unit do
+  defstruct [:magnitude, :short, :long]
+
+@doc """
+Fetches a unit's magnitude from a map of units
+"""
+def magnitude(units, unit) do
+  units
+  |> Map.fetch!(unit)
+  |> Map.fetch!(:magnitude)
+end
+
+
+end

--- a/test/benchee/conversion/count_test.exs
+++ b/test/benchee/conversion/count_test.exs
@@ -4,55 +4,55 @@ defmodule Benchee.Conversion.CountTest do
   doctest Benchee.Conversion.Count
 
   test ".scale 123_456_789_012 scales to :billion" do
-    assert scale(123_456_789_012) == {123.456789012, :billion}
+    assert scale(123_456_789_012) == {123.456789012, unit_for(:billion)}
   end
 
   test ".scale 12_345_678_901 scales to :billion" do
-    assert scale(12_345_678_901) == {12.345678901, :billion}
+    assert scale(12_345_678_901) == {12.345678901, unit_for(:billion)}
   end
 
   test ".scale 1_234_567_890 scales to :billion" do
-    assert scale(1_234_567_890) == {1.23456789, :billion}
+    assert scale(1_234_567_890) == {1.23456789, unit_for(:billion)}
   end
 
   test ".scale 123_456_789 scales to :million" do
-    assert scale(123_456_789) == {123.456789, :million}
+    assert scale(123_456_789) == {123.456789, unit_for(:million)}
   end
 
   test ".scale 12_345_678 scales to :million" do
-    assert scale(12_345_678) == {12.345678, :million}
+    assert scale(12_345_678) == {12.345678, unit_for(:million)}
   end
 
   test ".scale 1_234_567 scales to :million" do
-    assert scale(1_234_567) == {1.234567, :million}
+    assert scale(1_234_567) == {1.234567, unit_for(:million)}
   end
 
   test ".scale 123_456.7 scales to :thousand" do
-    assert scale(123_456.7) == {123.4567, :thousand}
+    assert scale(123_456.7) == {123.4567, unit_for(:thousand)}
   end
 
   test ".scale 12_345.67 scales to :thousand" do
-    assert scale(12_345.67) == {12.34567, :thousand}
+    assert scale(12_345.67) == {12.34567, unit_for(:thousand)}
   end
 
   test ".scale 1_234.567 scales to :thousand" do
-    assert scale(1_234.567) == {1.234567, :thousand}
+    assert scale(1_234.567) == {1.234567, unit_for(:thousand)}
   end
 
   test ".scale 123.4567 scales to :one" do
-    assert scale(123.4567) == {123.4567, :one}
+    assert scale(123.4567) == {123.4567, unit_for(:one)}
   end
 
   test ".scale 12.34567 scales to :one" do
-    assert scale(12.34567) == {12.34567, :one}
+    assert scale(12.34567) == {12.34567, unit_for(:one)}
   end
 
   test ".scale 1.234567 scales to :one" do
-    assert scale(1.234567) == {1.234567, :one}
+    assert scale(1.234567) == {1.234567, unit_for(:one)}
   end
 
   test ".scale 0.001234567 scales to :one" do
-    assert scale(0.001234567) == {0.001234567, :one}
+    assert scale(0.001234567) == {0.001234567, unit_for(:one)}
   end
 
   test ".format(1_000_000)" do
@@ -74,46 +74,46 @@ defmodule Benchee.Conversion.CountTest do
   @list_with_mostly_ones [1, 100, 1_000]
 
   test ".best when list is mostly ones" do
-    assert best(@list_with_mostly_ones) == :one
+    assert best(@list_with_mostly_ones) == unit_for(:one)
   end
 
   test ".best when list is mostly ones, strategy: :smallest" do
-    assert best(@list_with_mostly_ones, strategy: :smallest) == :one
+    assert best(@list_with_mostly_ones, strategy: :smallest) == unit_for(:one)
   end
 
   test ".best when list is mostly ones, strategy: :largest" do
-    assert best(@list_with_mostly_ones, strategy: :largest) == :thousand
+    assert best(@list_with_mostly_ones, strategy: :largest) == unit_for(:thousand)
   end
 
   @list_with_thousands_and_millions_tied_for_most [0.0001, 1, 1_000, 100_000, 1_000_000, 10_000_000, 1_000_000_000]
 
   test ".best when list has thousands and millions tied for most, billions highest" do
-    assert best(@list_with_thousands_and_millions_tied_for_most) == :million
+    assert best(@list_with_thousands_and_millions_tied_for_most) == unit_for(:million)
   end
 
   test ".best when list has thousands and millions tied for most, billions highest, strategy: :smallest" do
-    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :smallest) == :one
+    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :smallest) == unit_for(:one)
   end
 
   test ".best when list has thousands and millions tied for most, billions highest, strategy: :largest" do
-    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :largest) == :billion
+    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :largest) == unit_for(:billion)
   end
 
   @list_with_mostly_thousands [1_000, 2_000, 30_000, 999]
 
   test ".best when list is mostly thousands" do
-    assert best(@list_with_mostly_thousands) == :thousand
+    assert best(@list_with_mostly_thousands) == unit_for(:thousand)
   end
 
   test ".best when list is mostly thousands, strategy: :smallest" do
-    assert best(@list_with_mostly_thousands, strategy: :smallest) == :one
+    assert best(@list_with_mostly_thousands, strategy: :smallest) == unit_for(:one)
   end
 
   test ".best when list is mostly thousands, strategy: :largest" do
-    assert best(@list_with_mostly_thousands, strategy: :largest) == :thousand
+    assert best(@list_with_mostly_thousands, strategy: :largest) == unit_for(:thousand)
   end
 
   test ".best when list is mostly thousands, strategy: :none" do
-    assert best(@list_with_mostly_thousands, strategy: :none) == :one
+    assert best(@list_with_mostly_thousands, strategy: :none) == unit_for(:one)
   end
 end

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -42,18 +42,18 @@ defmodule Benchee.Conversion.DurationTest do
   @list_with_mostly_milliseconds [1, 200, 3_000, 4_000, 500_000, 6_000_000, 77_000_000_000]
 
   test ".best when list is mostly milliseconds" do
-    assert best(@list_with_mostly_milliseconds) == :millisecond
+    assert best(@list_with_mostly_milliseconds) == unit_for(:millisecond)
   end
 
   test ".best when list is mostly milliseconds, strategy: :smallest" do
-    assert best(@list_with_mostly_milliseconds, strategy: :smallest) == :microsecond
+    assert best(@list_with_mostly_milliseconds, strategy: :smallest) == unit_for(:microsecond)
   end
 
   test ".best when list is mostly milliseconds, strategy: :largest" do
-    assert best(@list_with_mostly_milliseconds, strategy: :largest) == :hour
+    assert best(@list_with_mostly_milliseconds, strategy: :largest) == unit_for(:hour)
   end
 
   test ".best when list is mostly milliseconds, strategy: :none" do
-    assert best(@list_with_mostly_milliseconds, strategy: :none) == :microsecond
+    assert best(@list_with_mostly_milliseconds, strategy: :none) == unit_for(:microsecond)
   end
 end


### PR DESCRIPTION
This was just an experiment, but I really like how it turned out, so I'm opening this PR for review. Note that it is based on #39, because it is an extension of that basic refactoring.

- converts units from plain maps to `Unit` structs
- remove `label/1`, `magnitude/1`, `separator/0` functions from `Count` and `Duration`
- add label and magnitude functionality to the Unit struct, as it better fits there anyway
- retain the option for a module like `Count` to define a `separator/0` function, but if not, just use a space