### PR TITLE
Proof of Concept use Unit struct more (acceptance tests passing)

### DIFF
--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -67,7 +67,7 @@ defmodule Benchee.Conversion.Count do
 
   # Helper function for returning a tuple of {value, unit}
   defp scale_with_unit(count, unit) do
-    {scale(count, unit), unit}
+    {scale(count, unit), Map.fetch!(@units, unit)}
   end
 
   @doc """
@@ -88,6 +88,9 @@ defmodule Benchee.Conversion.Count do
       0.012345
 
   """
+  def scale(count, unit = %Unit{}) do
+    Unit.scale count, unit
+  end
   def scale(count, :billion) do
     count / @one_billion
   end

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -60,7 +60,7 @@ defmodule Benchee.Conversion.Count do
       0.0045
       iex> unit.name
       :one
-      
+
   """
   def scale(count) when count >= @one_billion do
     scale_with_unit(count, :billion)
@@ -159,9 +159,18 @@ defmodule Benchee.Conversion.Count do
       iex> Benchee.Conversion.Count.format(45.6789)
       "45.68"
 
+      iex> Benchee.Conversion.Count.format({45.6789, :thousand})
+      "45.68 K"
+
       iex> Benchee.Conversion.Count.format({45.6789, %Benchee.Conversion.Unit{long: "Thousand", magnitude: "1_000", label: "K"}})
       "45.68 K"
   """
+  def format({count, unit = %Unit{}}) do
+    Format.format {count, unit}, __MODULE__
+  end
+  def format({count, unit_atom}) do
+    format {count, unit_for(unit_atom)}
+  end
   def format(count) do
     Format.format(count, __MODULE__)
   end

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -46,10 +46,14 @@ defmodule Benchee.Conversion.Count do
   ## Examples
 
       iex> Benchee.Conversion.Count.scale(4_321.09)
-      {4.32109, :thousand}
+      {4.32109, %Benchee.Conversion.Unit{long:      "Thousand",
+                                         magnitude: 1000,
+                                         short:     "K"}}
 
       iex> Benchee.Conversion.Count.scale(0.0045)
-      {0.0045, :one}
+      {0.0045, %Benchee.Conversion.Unit{long:      "",
+                                         magnitude: 1,
+                                         short:     ""}}
 
   """
   def scale(count) when count >= @one_billion do
@@ -80,7 +84,7 @@ defmodule Benchee.Conversion.Count do
   ## Examples
 
       iex> Benchee.Conversion.Count.scale(12345, :one)
-      12345
+      12345.0
 
       iex> Benchee.Conversion.Count.scale(12345, :thousand)
       12.345
@@ -109,16 +113,24 @@ defmodule Benchee.Conversion.Count do
   ## Examples
 
       iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000])
-      :thousand
+      %Benchee.Conversion.Unit{long:      "Thousand",
+                               magnitude: 1000,
+                               short:     "K"}
 
       iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000, 3_450_000])
-      :million
+      %Benchee.Conversion.Unit{long:      "Million",
+                               magnitude: 1_000_000,
+                               short:     "M"}
 
       iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest)
-      :one
+      %Benchee.Conversion.Unit{long:      "",
+                               magnitude: 1,
+                               short:     ""}
 
       iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :largest)
-      :million
+      %Benchee.Conversion.Unit{long:      "Million",
+                               magnitude: 1_000_000,
+                               short:     "M"}
 
   """
   def best(list, opts \\ [strategy: :best])
@@ -132,10 +144,10 @@ defmodule Benchee.Conversion.Count do
   ## Examples
 
       iex> Benchee.Conversion.Count.base_unit
-      :one
+      %Benchee.Conversion.Unit{long: "", magnitude: 1, short: ""}
 
   """
-  def base_unit, do: :one
+  def base_unit, do: unit_for(:one)
 
   @doc """
   Formats a number as a string, with a unit label. To specify the unit, pass
@@ -149,7 +161,7 @@ defmodule Benchee.Conversion.Count do
       iex> Benchee.Conversion.Count.format(45.6789)
       "45.68"
 
-      iex> Benchee.Conversion.Count.format({45.6789, :thousand})
+      iex> Benchee.Conversion.Count.format({45.6789, %Benchee.Conversion.Unit{long: "Thousand", magnitude: "1_000", short: "K"}})
       "45.68 K"
   """
   def format(count) do

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -49,18 +49,18 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.scale(4_321.09)
-      {4.32109, %Benchee.Conversion.Unit{name:      :thousand,
-                                         long:      "Thousand",
-                                         magnitude: 1000,
-                                         label:     "K"}}
+      iex> {value, unit} = Benchee.Conversion.Count.scale(4_321.09)
+      iex> value
+      4.32109
+      iex> unit.name
+      :thousand
 
-      iex> Benchee.Conversion.Count.scale(0.0045)
-      {0.0045, %Benchee.Conversion.Unit{name:      :one,
-                                        long:      "",
-                                        magnitude: 1,
-                                        label:     ""}}
-
+      iex> {value, unit} = Benchee.Conversion.Count.scale(0.0045)
+      iex> value
+      0.0045
+      iex> unit.name
+      :one
+      
   """
   def scale(count) when count >= @one_billion do
     scale_with_unit(count, :billion)

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -80,7 +80,20 @@ defmodule Benchee.Conversion.Count do
     {scale(count, unit), unit_for(unit)}
   end
 
-  defp unit_for(unit) do
+  @doc """
+  Get a unit by its atom representation.
+
+  ## Examples
+
+      iex> Benchee.Conversion.Count.unit_for :thousand
+      %Benchee.Conversion.Unit{
+        name:      :thousand,
+        magnitude: 1_000,
+        label:     "K",
+        long:      "Thousand"
+      }
+  """
+  def unit_for(unit) do
     Map.fetch! @units, unit
   end
 
@@ -102,11 +115,8 @@ defmodule Benchee.Conversion.Count do
       0.012345
 
   """
-  def scale(count, unit = %Unit{}) do
-    Unit.scale count, unit
-  end
-  def scale(count, unit_atom) do
-    scale count, unit_for(unit_atom)
+  def scale(count, unit) do
+    Scale.scale count, unit, __MODULE__
   end
 
   @doc """

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -67,7 +67,11 @@ defmodule Benchee.Conversion.Count do
 
   # Helper function for returning a tuple of {value, unit}
   defp scale_with_unit(count, unit) do
-    {scale(count, unit), Map.fetch!(@units, unit)}
+    {scale(count, unit), unit_for(unit)}
+  end
+
+  defp unit_for(unit) do
+    Map.fetch! @units, unit
   end
 
   @doc """
@@ -91,17 +95,8 @@ defmodule Benchee.Conversion.Count do
   def scale(count, unit = %Unit{}) do
     Unit.scale count, unit
   end
-  def scale(count, :billion) do
-    count / @one_billion
-  end
-  def scale(count, :million) do
-    count / @one_million
-  end
-  def scale(count, :thousand) do
-    count / @one_thousand
-  end
-  def scale(count, :one) do
-    count
+  def scale(count, unit_atom) do
+    scale count, unit_for(unit_atom)
   end
 
   @doc """

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -14,24 +14,28 @@ defmodule Benchee.Conversion.Count do
 
   @units %{
     billion:  %Unit{
+                name:      :billion,
                 magnitude: @one_billion,
-                short: "B",
-                long: "Billion"
+                label:     "B",
+                long:      "Billion"
               },
     million:  %Unit{
+                name:      :million,
                 magnitude: @one_million,
-                short: "M",
-                long: "Million"
+                label:     "M",
+                long:      "Million"
               },
     thousand: %Unit{
+                name:      :thousand,
                 magnitude: @one_thousand,
-                short: "K",
-                long: "Thousand"
+                label:     "K",
+                long:      "Thousand"
               },
     one:      %Unit{
+                name:      :one,
                 magnitude: 1,
-                short: "",
-                long: ""
+                label:     "",
+                long:      ""
               },
   }
 
@@ -46,14 +50,16 @@ defmodule Benchee.Conversion.Count do
   ## Examples
 
       iex> Benchee.Conversion.Count.scale(4_321.09)
-      {4.32109, %Benchee.Conversion.Unit{long:      "Thousand",
+      {4.32109, %Benchee.Conversion.Unit{name:      :thousand,
+                                         long:      "Thousand",
                                          magnitude: 1000,
-                                         short:     "K"}}
+                                         label:     "K"}}
 
       iex> Benchee.Conversion.Count.scale(0.0045)
-      {0.0045, %Benchee.Conversion.Unit{long:      "",
-                                         magnitude: 1,
-                                         short:     ""}}
+      {0.0045, %Benchee.Conversion.Unit{name:      :one,
+                                        long:      "",
+                                        magnitude: 1,
+                                        label:     ""}}
 
   """
   def scale(count) when count >= @one_billion do
@@ -112,25 +118,17 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000])
-      %Benchee.Conversion.Unit{long:      "Thousand",
-                               magnitude: 1000,
-                               short:     "K"}
+      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000]).name
+      :thousand
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000, 3_450_000])
-      %Benchee.Conversion.Unit{long:      "Million",
-                               magnitude: 1_000_000,
-                               short:     "M"}
+      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000, 3_450_000]).name
+      :million
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest)
-      %Benchee.Conversion.Unit{long:      "",
-                               magnitude: 1,
-                               short:     ""}
+      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
+      :one
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :largest)
-      %Benchee.Conversion.Unit{long:      "Million",
-                               magnitude: 1_000_000,
-                               short:     "M"}
+      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :largest).name
+      :million
 
   """
   def best(list, opts \\ [strategy: :best])
@@ -143,8 +141,8 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.base_unit
-      %Benchee.Conversion.Unit{long: "", magnitude: 1, short: ""}
+      iex> Benchee.Conversion.Count.base_unit.name
+      :one
 
   """
   def base_unit, do: unit_for(:one)
@@ -161,7 +159,7 @@ defmodule Benchee.Conversion.Count do
       iex> Benchee.Conversion.Count.format(45.6789)
       "45.68"
 
-      iex> Benchee.Conversion.Count.format({45.6789, %Benchee.Conversion.Unit{long: "Thousand", magnitude: "1_000", short: "K"}})
+      iex> Benchee.Conversion.Count.format({45.6789, %Benchee.Conversion.Unit{long: "Thousand", magnitude: "1_000", label: "K"}})
       "45.68 K"
   """
   def format(count) do

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -40,11 +40,6 @@ defmodule Benchee.Conversion.Count do
   }
 
   @doc """
-  Units of count, in powers of 1_000: :one, :thousand, :million, :billion
-  """
-  def units, do: @units
-
-  @doc """
   Scales a value representing a count in ones into a larger unit if appropriate
 
   ## Examples

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -94,7 +94,7 @@ defmodule Benchee.Conversion.Count do
       }
   """
   def unit_for(unit) do
-    Map.fetch! @units, unit
+    Scale.unit_for @units, unit
   end
 
   @doc """

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -175,12 +175,6 @@ defmodule Benchee.Conversion.Count do
       iex> Benchee.Conversion.Count.format({45.6789, %Benchee.Conversion.Unit{long: "Thousand", magnitude: "1_000", label: "K"}})
       "45.68 K"
   """
-  def format({count, unit = %Unit{}}) do
-    Format.format {count, unit}, __MODULE__
-  end
-  def format({count, unit_atom}) do
-    format {count, unit_for(unit_atom)}
-  end
   def format(count) do
     Format.format(count, __MODULE__)
   end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -59,24 +59,23 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.scale(1)
-      {1.0, %Benchee.Conversion.Unit{name:      :microsecond,
-                                     long:      "Microseconds",
-                                     magnitude: 1,
-                                     label:     "μs"}}
+      iex> {value, unit} = Benchee.Conversion.Duration.scale(1)
+      iex> value
+      1.0
+      iex> unit.name
+      :microsecond
 
-      iex> Benchee.Conversion.Duration.scale(1_234)
-      {1.234, %Benchee.Conversion.Unit{name:      :millisecond,
-                                       long:      "Milliseconds",
-                                       magnitude: 1000,
-                                       label:     "ms"}}
+      iex> {value, unit} = Benchee.Conversion.Duration.scale(1_234)
+      iex> value
+      1.234
+      iex> unit.name
+      :millisecond
 
-      iex> Benchee.Conversion.Duration.scale(11_234_567_890.123)
-      {3.1207133028119443, %Benchee.Conversion.Unit{name:      :hour,
-                                                    long: "Hours",
-                                                    magnitude: 3600000000,
-                                                    label: "h"}}
-
+      iex> {value, unit} = Benchee.Conversion.Duration.scale(11_234_567_890.123)
+      iex> value
+      3.1207133028119443
+      iex> unit.name
+      :hour
   """
   def scale(duration) when duration >= @microseconds_per_hour do
     scale_with_unit duration, :hour

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -98,7 +98,20 @@ defmodule Benchee.Conversion.Duration do
     {scale(duration, unit), unit_for(unit)}
   end
 
-  defp unit_for(unit) do
+  @doc """
+  Get a unit by its atom representation.
+
+  ## Examples
+
+      iex> Benchee.Conversion.Duration.unit_for :hour
+      %Benchee.Conversion.Unit{
+        name:      :hour,
+        magnitude: 3_600_000_000,
+        label:     "h",
+        long:      "Hours"
+      }
+  """
+  def unit_for(unit) do
     Map.fetch! @units, unit
   end
 
@@ -117,11 +130,8 @@ defmodule Benchee.Conversion.Duration do
       2.0575e-4
 
   """
-  def scale(duration, unit = %Unit{}) do
-    Unit.scale duration, unit
-  end
-  def scale(duration, unit_atom) do
-    scale duration, unit_for(unit_atom)
+  def scale(count, unit) do
+    Scale.scale count, unit, __MODULE__
   end
 
   @doc """

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -82,7 +82,7 @@ defmodule Benchee.Conversion.Duration do
 
   # Helper function for returning a tuple of {value, unit}
   defp scale_with_unit(duration, unit) do
-    {scale(duration, unit), unit}
+    {scale(duration, unit), Map.fetch!(@units, unit)}
   end
 
   @doc """
@@ -100,6 +100,9 @@ defmodule Benchee.Conversion.Duration do
       2.0575e-4
 
   """
+  def scale(duration, unit = %Unit{}) do
+    Unit.scale duration, unit
+  end
   def scale(duration, :hour) do
     duration / @microseconds_per_hour
   end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -204,10 +204,19 @@ defmodule Benchee.Conversion.Duration do
       iex> Benchee.Conversion.Duration.format(45.6789)
       "45.68 μs"
 
+      iex> Benchee.Conversion.Duration.format({45.6789, :millisecond})
+      "45.68 ms"
+
       iex> Benchee.Conversion.Duration.format({45.6789, %Benchee.Conversion.Unit{long: "Milliseconds", magnitude: 1000, label: "ms"}})
       "45.68 ms"
 
   """
+  def format({count, unit = %Unit{}}) do
+    Format.format {count, unit}, __MODULE__
+  end
+  def format({count, unit_atom}) do
+    format {count, unit_for(unit_atom)}
+  end
   def format(count) do
     Format.format(count, __MODULE__)
   end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -139,20 +139,11 @@ defmodule Benchee.Conversion.Duration do
       1.234
 
   """
-  def microseconds({duration, :hour}) do
-    duration * @microseconds_per_hour
+  def microseconds({duration, unit = %Unit{}}) do
+    duration * unit.magnitude
   end
-  def microseconds({duration, :minute}) do
-    duration * @microseconds_per_minute
-  end
-  def microseconds({duration, :second}) do
-    duration * @microseconds_per_second
-  end
-  def microseconds({duration, :millisecond}) do
-    duration * @microseconds_per_millisecond
-  end
-  def microseconds({duration, :microsecond}) do
-    duration
+  def microseconds({duration, unit_atom}) do
+    microseconds {duration, unit_for(unit_atom)}
   end
 
   @doc """

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -55,13 +55,17 @@ defmodule Benchee.Conversion.Duration do
   ## Examples
 
       iex> Benchee.Conversion.Duration.scale(1)
-      {1, :microsecond}
+      {1.0, %Benchee.Conversion.Unit{long:      "Microseconds",
+                                   magnitude: 1,
+                                   short:     "μs"}}
 
       iex> Benchee.Conversion.Duration.scale(1_234)
-      {1.234, :millisecond}
+      {1.234, %Benchee.Conversion.Unit{long:      "Milliseconds",
+                                       magnitude: 1000,
+                                       short:     "ms"}}
 
       iex> Benchee.Conversion.Duration.scale(11_234_567_890.123)
-      {3.1207133028119443, :hour}
+      {3.1207133028119443, %Benchee.Conversion.Unit{long: "Hours", magnitude: 3600000000, short: "h"}}
 
   """
   def scale(duration) when duration >= @microseconds_per_hour do
@@ -95,7 +99,7 @@ defmodule Benchee.Conversion.Duration do
   ## Examples
 
       iex> Benchee.Conversion.Duration.scale(12345, :microsecond)
-      12345
+      12345.0
 
       iex> Benchee.Conversion.Duration.scale(12345, :millisecond)
       12.345
@@ -152,16 +156,24 @@ defmodule Benchee.Conversion.Duration do
   ## Examples
 
       iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000])
-      :millisecond
+      %Benchee.Conversion.Unit{long:      "Milliseconds",
+                               magnitude: 1000,
+                               short:     "ms"}
 
       iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000, 3_450_000])
-      :second
+      %Benchee.Conversion.Unit{long:      "Seconds",
+                               magnitude: 1_000_000,
+                               short:     "s"}
 
       iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest)
-      :microsecond
+      %Benchee.Conversion.Unit{long:      "Microseconds",
+                               magnitude: 1,
+                               short:     "μs"}
 
       iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000], strategy: :largest)
-      :second
+      %Benchee.Conversion.Unit{long:      "Seconds",
+                               magnitude: 1_000_000,
+                               short:     "s"}
   """
   def best(list, opts \\ [strategy: :best])
   def best(list, opts) do
@@ -174,10 +186,12 @@ defmodule Benchee.Conversion.Duration do
   ## Examples
 
       iex> Benchee.Conversion.Duration.base_unit
-      :microsecond
+      %Benchee.Conversion.Unit{long:      "Microseconds",
+                               magnitude: 1,
+                               short:     "μs"}
 
   """
-  def base_unit, do: :microsecond
+  def base_unit, do: unit_for(:microsecond)
 
   @doc """
   Formats a number as a string, with a unit label. To specify the unit, pass
@@ -191,7 +205,7 @@ defmodule Benchee.Conversion.Duration do
       iex> Benchee.Conversion.Duration.format(45.6789)
       "45.68 μs"
 
-      iex> Benchee.Conversion.Duration.format({45.6789, :millisecond})
+      iex> Benchee.Conversion.Duration.format({45.6789, %Benchee.Conversion.Unit{long: "Milliseconds", magnitude: 1000, short: "ms"}})
       "45.68 ms"
 
   """

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -112,7 +112,7 @@ defmodule Benchee.Conversion.Duration do
       }
   """
   def unit_for(unit) do
-    Map.fetch! @units, unit
+    Scale.unit_for @units, unit
   end
 
   @doc """

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -50,11 +50,6 @@ defmodule Benchee.Conversion.Duration do
   }
 
   @doc """
-  Units of duration: :microsecond, :millisecond, :second, :minute, :hour
-  """
-  def units, do: @units
-
-  @doc """
   Scales a duration value in microseconds into a larger unit if appropriate
 
   ## Examples

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -212,13 +212,7 @@ defmodule Benchee.Conversion.Duration do
       "45.68 ms"
 
   """
-  def format({count, unit = %Unit{}}) do
-    Format.format {count, unit}, __MODULE__
-  end
-  def format({count, unit_atom}) do
-    format {count, unit_for(unit_atom)}
-  end
-  def format(count) do
-    Format.format(count, __MODULE__)
+  def format(duration) do
+    Format.format(duration, __MODULE__)
   end
 end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -82,7 +82,11 @@ defmodule Benchee.Conversion.Duration do
 
   # Helper function for returning a tuple of {value, unit}
   defp scale_with_unit(duration, unit) do
-    {scale(duration, unit), Map.fetch!(@units, unit)}
+    {scale(duration, unit), unit_for(unit)}
+  end
+
+  defp unit_for(unit) do
+    Map.fetch! @units, unit
   end
 
   @doc """
@@ -103,20 +107,8 @@ defmodule Benchee.Conversion.Duration do
   def scale(duration, unit = %Unit{}) do
     Unit.scale duration, unit
   end
-  def scale(duration, :hour) do
-    duration / @microseconds_per_hour
-  end
-  def scale(duration, :minute) do
-    duration / @microseconds_per_minute
-  end
-  def scale(duration, :second) do
-    duration / @microseconds_per_second
-  end
-  def scale(duration, :millisecond) do
-    duration / @microseconds_per_millisecond
-  end
-  def scale(duration, :microsecond) do
-    duration
+  def scale(duration, unit_atom) do
+    scale duration, unit_for(unit_atom)
   end
 
   @doc """

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -18,29 +18,34 @@ defmodule Benchee.Conversion.Duration do
 
   @units %{
     hour:        %Unit{
+                    name:      :hour,
                     magnitude: @microseconds_per_hour,
-                    short:     "h",
+                    label:     "h",
                     long:      "Hours"
                  },
     minute:      %Unit{
+                    name:      :minute,
                     magnitude: @microseconds_per_minute,
-                    short:     "m",
+                    label:     "m",
                     long: "Minutes"
                  },
     second:      %Unit{
+                    name:      :second,
                     magnitude: @microseconds_per_second,
-                    short:     "s",
+                    label:     "s",
                     long:      "Seconds"
                  },
     millisecond: %Unit{
+                    name:      :millisecond,
                     magnitude: @microseconds_per_millisecond,
-                    short:     "ms",
+                    label:     "ms",
                     long:      "Milliseconds"
                  },
     microsecond: %Unit{
+                    name:      :microsecond,
                     magnitude: 1,
-                    short:     "μs",
-                    long: "Microseconds"
+                    label:     "μs",
+                    long:     "Microseconds"
                  }
   }
 
@@ -55,17 +60,22 @@ defmodule Benchee.Conversion.Duration do
   ## Examples
 
       iex> Benchee.Conversion.Duration.scale(1)
-      {1.0, %Benchee.Conversion.Unit{long:      "Microseconds",
-                                   magnitude: 1,
-                                   short:     "μs"}}
+      {1.0, %Benchee.Conversion.Unit{name:      :microsecond,
+                                     long:      "Microseconds",
+                                     magnitude: 1,
+                                     label:     "μs"}}
 
       iex> Benchee.Conversion.Duration.scale(1_234)
-      {1.234, %Benchee.Conversion.Unit{long:      "Milliseconds",
+      {1.234, %Benchee.Conversion.Unit{name:      :millisecond,
+                                       long:      "Milliseconds",
                                        magnitude: 1000,
-                                       short:     "ms"}}
+                                       label:     "ms"}}
 
       iex> Benchee.Conversion.Duration.scale(11_234_567_890.123)
-      {3.1207133028119443, %Benchee.Conversion.Unit{long: "Hours", magnitude: 3600000000, short: "h"}}
+      {3.1207133028119443, %Benchee.Conversion.Unit{name:      :hour,
+                                                    long: "Hours",
+                                                    magnitude: 3600000000,
+                                                    label: "h"}}
 
   """
   def scale(duration) when duration >= @microseconds_per_hour do
@@ -155,25 +165,17 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000])
-      %Benchee.Conversion.Unit{long:      "Milliseconds",
-                               magnitude: 1000,
-                               short:     "ms"}
+      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000]).name
+      :millisecond
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000, 3_450_000])
-      %Benchee.Conversion.Unit{long:      "Seconds",
-                               magnitude: 1_000_000,
-                               short:     "s"}
+      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000, 3_450_000]).name
+      :second
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest)
-      %Benchee.Conversion.Unit{long:      "Microseconds",
-                               magnitude: 1,
-                               short:     "μs"}
+      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
+      :microsecond
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000], strategy: :largest)
-      %Benchee.Conversion.Unit{long:      "Seconds",
-                               magnitude: 1_000_000,
-                               short:     "s"}
+      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000], strategy: :largest).name
+      :second
   """
   def best(list, opts \\ [strategy: :best])
   def best(list, opts) do
@@ -185,10 +187,8 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.base_unit
-      %Benchee.Conversion.Unit{long:      "Microseconds",
-                               magnitude: 1,
-                               short:     "μs"}
+      iex> Benchee.Conversion.Duration.base_unit.name
+      :microsecond
 
   """
   def base_unit, do: unit_for(:microsecond)
@@ -205,7 +205,7 @@ defmodule Benchee.Conversion.Duration do
       iex> Benchee.Conversion.Duration.format(45.6789)
       "45.68 μs"
 
-      iex> Benchee.Conversion.Duration.format({45.6789, %Benchee.Conversion.Unit{long: "Milliseconds", magnitude: 1000, short: "ms"}})
+      iex> Benchee.Conversion.Duration.format({45.6789, %Benchee.Conversion.Unit{long: "Milliseconds", magnitude: 1000, label: "ms"}})
       "45.68 ms"
 
   """

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -144,8 +144,8 @@ defmodule Benchee.Conversion.Duration do
       1.234
 
   """
-  def microseconds({duration, unit = %Unit{}}) do
-    duration * unit.magnitude
+  def microseconds({duration, %Unit{magnitude: magnitude}}) do
+    duration * magnitude
   end
   def microseconds({duration, unit_atom}) do
     microseconds {duration, unit_for(unit_atom)}

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -68,7 +68,7 @@ defmodule Benchee.Conversion.Format do
 
   # Fetches the label for the given unit
   defp label(module, unit) do
-    Unit.label(module, unit)
+    unit.short
   end
 
   defp float_precision(float) when float < 0.01, do: 5

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -38,7 +38,7 @@ defmodule Benchee.Conversion.Format do
   (a single space) will be used.
   """
   def format({count, unit}, module) do
-    format(count, label(module, unit), separator(module))
+    format(count, label(unit), separator(module))
   end
 
   @doc """
@@ -67,7 +67,7 @@ defmodule Benchee.Conversion.Format do
   defp separator(_label, separator), do: separator
 
   # Fetches the label for the given unit
-  defp label(module, unit = %Unit{}) do
+  defp label(unit = %Unit{}) do
     unit.label
   end
 

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -70,8 +70,8 @@ defmodule Benchee.Conversion.Format do
   defp separator(_label, separator), do: separator
 
   # Fetches the label for the given unit
-  defp label(unit = %Unit{}) do
-    unit.label
+  defp label(%Unit{label: label}) do
+    label
   end
 
   defp float_precision(float) when float < 0.01, do: 5

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -67,7 +67,7 @@ defmodule Benchee.Conversion.Format do
   defp separator(_label, separator), do: separator
 
   # Fetches the label for the given unit
-  defp label(module, unit) do
+  defp label(module, unit = %Unit{}) do
     unit.short
   end
 

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -37,8 +37,11 @@ defmodule Benchee.Conversion.Format do
   formatted output. If no `separator/0` function exists, the default separator
   (a single space) will be used.
   """
-  def format({count, unit}, module) do
+  def format({count, unit = %Unit{}}, module) do
     format(count, label(unit), separator(module))
+  end
+  def format({count, unit_atom}, module) do
+    format({count, module.unit_for(unit_atom)}, module)
   end
 
   @doc """

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -68,7 +68,7 @@ defmodule Benchee.Conversion.Format do
 
   # Fetches the label for the given unit
   defp label(module, unit = %Unit{}) do
-    unit.short
+    unit.label
   end
 
   defp float_precision(float) when float < 0.01, do: 5

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -8,7 +8,9 @@ defmodule Benchee.Conversion.Scale do
 
   alias Benchee.Conversion.Unit
 
-  @type unit :: atom
+  @type unit :: Unit.t
+  @type unit_atom :: atom
+  @type any_unit :: unit | unit_atom
   @type scaled_number :: {number, unit}
 
   # In 1.3, this could be declared as `keyword`, but use a custom type so it
@@ -27,7 +29,7 @@ defmodule Benchee.Conversion.Scale do
   specified unit. Results are a `{number, unit}` tuple. See
   `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
   """
-  @callback scale(number, unit) :: number
+  @callback scale(number, any_unit) :: number
 
   @doc """
   Finds the best fit unit for a list of numbers in a domain's base unit.
@@ -41,6 +43,12 @@ defmodule Benchee.Conversion.Scale do
   general is the smallest supported unit.
   """
   @callback base_unit :: unit
+
+  @doc """
+  Given the atom representation of a unit (`:hour`) return the appropriate
+  `Benchee.Conversion.Unit` struct.
+  """
+  @callback unit_for(unit_atom) :: unit
 
   # Generic scaling functions
 

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -137,7 +137,7 @@ defmodule Benchee.Conversion.Scale do
     |> Enum.map(fn n -> scale_unit(n, module) end)
     |> Enum.group_by(fn unit -> unit end)
     |> Enum.map(fn {unit, occurrences} -> {unit, length(occurrences)} end)
-    |> Enum.sort(fn unit, freq -> by_frequency_and_magnitude(unit, freq, module) end)
+    |> Enum.sort(fn unit, freq -> by_frequency_and_magnitude(unit, freq) end)
     |> hd
     |> elem(0)
   end
@@ -146,14 +146,14 @@ defmodule Benchee.Conversion.Scale do
   defp smallest_unit(list, module) do
     list
     |> Enum.map(fn n -> scale_unit(n, module) end)
-    |> Enum.min_by(fn unit -> magnitude(module, unit) end)
+    |> Enum.min_by(fn unit -> magnitude(unit) end)
   end
 
   # Finds the largest unit in the list
   defp largest_unit(list, module) do
     list
     |> Enum.map(fn n -> scale_unit(n, module) end)
-    |> Enum.max_by(fn unit -> magnitude(module, unit) end)
+    |> Enum.max_by(fn unit -> magnitude(unit) end)
   end
 
   defp scale_unit(count, module) do
@@ -162,16 +162,16 @@ defmodule Benchee.Conversion.Scale do
   end
 
   # Fetches the magnitude for the given unit
-  defp magnitude(_module, unit) do
-    unit.magnitude
+  defp magnitude(%Unit{magnitude: magnitude}) do
+    magnitude
   end
 
   # Sorts two elements first by total, then by magnitude of the unit in case
   # of tie
-  defp by_frequency_and_magnitude({unit_a, frequency}, {unit_b, frequency}, module) do
-    magnitude(module, unit_a) > magnitude(module, unit_b)
+  defp by_frequency_and_magnitude({unit_a, frequency}, {unit_b, frequency}) do
+    magnitude(unit_a) > magnitude(unit_b)
   end
-  defp by_frequency_and_magnitude({_, frequency_a}, {_, frequency_b}, _module) do
+  defp by_frequency_and_magnitude({_, frequency_a}, {_, frequency_b}) do
     frequency_a > frequency_b
   end
 end

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -73,6 +73,13 @@ defmodule Benchee.Conversion.Scale do
     value / magnitude
   end
 
+  @doc """
+  Lookup a unit by its `atom` presentation for the representation of supported
+  units. Used by `Benchee.Conversion.Duration` and `Benchee.Conversion.Count`.
+  """
+  def unit_for(units, unit) do
+    Map.fetch! units, unit
+  end
 
   @doc """
   Given a `list` of number values and a `module` describing the domain of the

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -66,15 +66,19 @@ defmodule Benchee.Conversion.Scale do
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
       iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best)
-      :thousand
+      %Benchee.Conversion.Unit{long:      "Thousand",
+                               magnitude: 1_000,
+                               short:     "K"}
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
       iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :smallest)
-      :one
+      %Benchee.Conversion.Unit{long: "", magnitude: 1, short: ""}
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
       iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :largest)
-      :million
+      %Benchee.Conversion.Unit{long:      "Million",
+                               magnitude: 1_000_000,
+                               short:     "M"}
   """
   def best_unit(list, module, opts) do
     case Keyword.get(opts, :strategy, :best) do

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -6,6 +6,8 @@ defmodule Benchee.Conversion.Scale do
   See `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
   """
 
+  alias Benchee.Conversion.Unit
+
   @type unit :: atom
   @type scaled_number :: {number, unit}
 
@@ -41,6 +43,36 @@ defmodule Benchee.Conversion.Scale do
   @callback base_unit :: unit
 
   # Generic scaling functions
+
+  @doc """
+  Used internally by implemented units to handle their scaling with units and
+  without.
+
+  ## Examples
+
+      iex> Benchee.Conversion.Scale.scale(12345, :thousand, Benchee.Conversion.Count)
+      12.345
+  """
+  def scale(value, unit = %Unit{}, _module) do
+    scale(value, unit)
+  end
+  def scale(value, unit_atom, module) do
+    scale value, module.unit_for(unit_atom)
+  end
+
+  @doc """
+  Used internally for scaling but only supports scaling with actual units.
+
+  ## Examples
+
+      iex> unit = %Benchee.Conversion.Unit{magnitude: 1000}
+      iex> Benchee.Conversion.Scale.scale 12345, unit
+      12.345
+  """
+  def scale(value, %Unit{magnitude: magnitude}) do
+    value / magnitude
+  end
+
 
   @doc """
   Given a `list` of number values and a `module` describing the domain of the

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -6,8 +6,6 @@ defmodule Benchee.Conversion.Scale do
   See `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
   """
 
-  alias Benchee.Conversion.Unit
-
   @type unit :: atom
   @type scaled_number :: {number, unit}
 
@@ -65,20 +63,16 @@ defmodule Benchee.Conversion.Scale do
   ## Examples
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best)
-      %Benchee.Conversion.Unit{long:      "Thousand",
-                               magnitude: 1_000,
-                               short:     "K"}
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      :thousand
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :smallest)
-      %Benchee.Conversion.Unit{long: "", magnitude: 1, short: ""}
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :smallest).name
+      :one
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :largest)
-      %Benchee.Conversion.Unit{long:      "Million",
-                               magnitude: 1_000_000,
-                               short:     "M"}
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :largest).name
+      :million
   """
   def best_unit(list, module, opts) do
     case Keyword.get(opts, :strategy, :best) do

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -117,8 +117,8 @@ defmodule Benchee.Conversion.Scale do
   end
 
   # Fetches the magnitude for the given unit
-  defp magnitude(module, unit) do
-    Unit.magnitude(module, unit)
+  defp magnitude(_module, unit) do
+    unit.magnitude
   end
 
   # Sorts two elements first by total, then by magnitude of the unit in case

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -1,5 +1,5 @@
 defmodule Benchee.Conversion.Unit do
-  defstruct [:magnitude, :short, :long]
+  defstruct [:name, :magnitude, :label, :long]
 
   alias Benchee.Conversion.Unit
 

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -1,5 +1,8 @@
 defmodule Benchee.Conversion.Unit do
   defstruct [:name, :magnitude, :label, :long]
+  @type t :: %Benchee.Conversion.Unit{name:      atom,
+                                      magnitude: non_neg_integer,
+                                      label:     String.t,
+                                      long:      String.t}
 
-  alias Benchee.Conversion.Unit
 end

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -1,57 +1,9 @@
 defmodule Benchee.Conversion.Unit do
   defstruct [:magnitude, :short, :long]
 
-  @doc """
-  The magnitude of the given unit. Requires that `module` implements `units/0`,
-  and that `unit` is one of `module`'s units
+  alias Benchee.Conversion.Unit
 
-  ## Examples
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Duration, :millisecond)
-      1000
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Duration, :microsecond)
-      1
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Count, :million)
-      1000000
-
-      iex> Benchee.Conversion.Unit.magnitude(Benchee.Conversion.Count, :one)
-      1
-
-
-  """
-  def magnitude(module, unit) do
-    fetch_nested_unit_field(module, unit, :magnitude)
-  end
-
-  @doc """
-  The label for the given unit. Requires that `module` implements `units/0`,
-  and that `unit` is one of `module`'s units
-
-  ## Examples
-
-      iex> Benchee.Conversion.Unit.label(Benchee.Conversion.Count, :million)
-      "M"
-
-      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Count, :one)
-      ""
-
-      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Duration, :millisecond)
-      "ms"
-
-      iex> Benchee.Conversion.Count.label(Benchee.Conversion.Duration, :microsecond)
-      "μs"
-
-  """
-  def label(module, unit) do
-    fetch_nested_unit_field(module, unit, :short)
-  end
-
-  # Fetches the value of `field` from the `unit` in module's Map of units, `units/0`
-  defp fetch_nested_unit_field(module, unit, field) do
-    module.units()
-    |> Map.fetch!(unit)
-    |> Map.fetch!(field)
+  def scale(value, %Unit{magnitude: magnitude}) do
+    value / magnitude
   end
 end

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -2,8 +2,4 @@ defmodule Benchee.Conversion.Unit do
   defstruct [:name, :magnitude, :label, :long]
 
   alias Benchee.Conversion.Unit
-
-  def scale(value, %Unit{magnitude: magnitude}) do
-    value / magnitude
-  end
 end

--- a/test/benchee/conversion/count_test.exs
+++ b/test/benchee/conversion/count_test.exs
@@ -1,58 +1,63 @@
 defmodule Benchee.Conversion.CountTest do
   use ExUnit.Case
+  alias Benchee.Conversion.Count
   import Benchee.Conversion.Count
   doctest Benchee.Conversion.Count
 
+  defp unit_for(unit_atom) do
+    Map.fetch! Count.units, unit_atom
+  end
+
   test ".scale 123_456_789_012 scales to :billion" do
-    assert scale(123_456_789_012) == {123.456789012, :billion}
+    assert scale(123_456_789_012) == {123.456789012, unit_for(:billion)}
   end
 
   test ".scale 12_345_678_901 scales to :billion" do
-    assert scale(12_345_678_901) == {12.345678901, :billion}
+    assert scale(12_345_678_901) == {12.345678901, unit_for(:billion)}
   end
 
   test ".scale 1_234_567_890 scales to :billion" do
-    assert scale(1_234_567_890) == {1.23456789, :billion}
+    assert scale(1_234_567_890) == {1.23456789, unit_for(:billion)}
   end
 
   test ".scale 123_456_789 scales to :million" do
-    assert scale(123_456_789) == {123.456789, :million}
+    assert scale(123_456_789) == {123.456789, unit_for(:million)}
   end
 
   test ".scale 12_345_678 scales to :million" do
-    assert scale(12_345_678) == {12.345678, :million}
+    assert scale(12_345_678) == {12.345678, unit_for(:million)}
   end
 
   test ".scale 1_234_567 scales to :million" do
-    assert scale(1_234_567) == {1.234567, :million}
+    assert scale(1_234_567) == {1.234567, unit_for(:million)}
   end
 
   test ".scale 123_456.7 scales to :thousand" do
-    assert scale(123_456.7) == {123.4567, :thousand}
+    assert scale(123_456.7) == {123.4567, unit_for(:thousand)}
   end
 
   test ".scale 12_345.67 scales to :thousand" do
-    assert scale(12_345.67) == {12.34567, :thousand}
+    assert scale(12_345.67) == {12.34567, unit_for(:thousand)}
   end
 
   test ".scale 1_234.567 scales to :thousand" do
-    assert scale(1_234.567) == {1.234567, :thousand}
+    assert scale(1_234.567) == {1.234567, unit_for(:thousand)}
   end
 
   test ".scale 123.4567 scales to :one" do
-    assert scale(123.4567) == {123.4567, :one}
+    assert scale(123.4567) == {123.4567, unit_for(:one)}
   end
 
   test ".scale 12.34567 scales to :one" do
-    assert scale(12.34567) == {12.34567, :one}
+    assert scale(12.34567) == {12.34567, unit_for(:one)}
   end
 
   test ".scale 1.234567 scales to :one" do
-    assert scale(1.234567) == {1.234567, :one}
+    assert scale(1.234567) == {1.234567, unit_for(:one)}
   end
 
   test ".scale 0.001234567 scales to :one" do
-    assert scale(0.001234567) == {0.001234567, :one}
+    assert scale(0.001234567) == {0.001234567, unit_for(:one)}
   end
 
   test ".format(1_000_000)" do
@@ -74,46 +79,46 @@ defmodule Benchee.Conversion.CountTest do
   @list_with_mostly_ones [1, 100, 1_000]
 
   test ".best when list is mostly ones" do
-    assert best(@list_with_mostly_ones) == :one
+    assert best(@list_with_mostly_ones) == unit_for(:one)
   end
 
   test ".best when list is mostly ones, strategy: :smallest" do
-    assert best(@list_with_mostly_ones, strategy: :smallest) == :one
+    assert best(@list_with_mostly_ones, strategy: :smallest) == unit_for(:one)
   end
 
   test ".best when list is mostly ones, strategy: :largest" do
-    assert best(@list_with_mostly_ones, strategy: :largest) == :thousand
+    assert best(@list_with_mostly_ones, strategy: :largest) == unit_for(:thousand)
   end
 
   @list_with_thousands_and_millions_tied_for_most [0.0001, 1, 1_000, 100_000, 1_000_000, 10_000_000, 1_000_000_000]
 
   test ".best when list has thousands and millions tied for most, billions highest" do
-    assert best(@list_with_thousands_and_millions_tied_for_most) == :million
+    assert best(@list_with_thousands_and_millions_tied_for_most) == unit_for(:million)
   end
 
   test ".best when list has thousands and millions tied for most, billions highest, strategy: :smallest" do
-    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :smallest) == :one
+    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :smallest) == unit_for(:one)
   end
 
   test ".best when list has thousands and millions tied for most, billions highest, strategy: :largest" do
-    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :largest) == :billion
+    assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :largest) == unit_for(:billion)
   end
 
   @list_with_mostly_thousands [1_000, 2_000, 30_000, 999]
 
   test ".best when list is mostly thousands" do
-    assert best(@list_with_mostly_thousands) == :thousand
+    assert best(@list_with_mostly_thousands) == unit_for(:thousand)
   end
 
   test ".best when list is mostly thousands, strategy: :smallest" do
-    assert best(@list_with_mostly_thousands, strategy: :smallest) == :one
+    assert best(@list_with_mostly_thousands, strategy: :smallest) == unit_for(:one)
   end
 
   test ".best when list is mostly thousands, strategy: :largest" do
-    assert best(@list_with_mostly_thousands, strategy: :largest) == :thousand
+    assert best(@list_with_mostly_thousands, strategy: :largest) == unit_for(:thousand)
   end
 
   test ".best when list is mostly thousands, strategy: :none" do
-    assert best(@list_with_mostly_thousands, strategy: :none) == :one
+    assert best(@list_with_mostly_thousands, strategy: :none) == unit_for(:one)
   end
 end

--- a/test/benchee/conversion/count_test.exs
+++ b/test/benchee/conversion/count_test.exs
@@ -1,12 +1,7 @@
 defmodule Benchee.Conversion.CountTest do
   use ExUnit.Case
-  alias Benchee.Conversion.Count
   import Benchee.Conversion.Count
   doctest Benchee.Conversion.Count
-
-  defp unit_for(unit_atom) do
-    Map.fetch! Count.units, unit_atom
-  end
 
   test ".scale 123_456_789_012 scales to :billion" do
     assert scale(123_456_789_012) == {123.456789012, unit_for(:billion)}

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -3,6 +3,10 @@ defmodule Benchee.Conversion.DurationTest do
   import Benchee.Conversion.Duration
   doctest Benchee.Conversion.Duration
 
+  defp unit_for(unit_atom) do
+    Map.fetch! Benchee.Conversion.Duration.units, unit_atom
+  end
+
   test ".format(98.7654321)" do
     assert format(98.7654321) == "98.77 μs"
   end
@@ -42,18 +46,18 @@ defmodule Benchee.Conversion.DurationTest do
   @list_with_mostly_milliseconds [1, 200, 3_000, 4_000, 500_000, 6_000_000, 77_000_000_000]
 
   test ".best when list is mostly milliseconds" do
-    assert best(@list_with_mostly_milliseconds) == :millisecond
+    assert best(@list_with_mostly_milliseconds) == unit_for(:millisecond)
   end
 
   test ".best when list is mostly milliseconds, strategy: :smallest" do
-    assert best(@list_with_mostly_milliseconds, strategy: :smallest) == :microsecond
+    assert best(@list_with_mostly_milliseconds, strategy: :smallest) == unit_for(:microsecond)
   end
 
   test ".best when list is mostly milliseconds, strategy: :largest" do
-    assert best(@list_with_mostly_milliseconds, strategy: :largest) == :hour
+    assert best(@list_with_mostly_milliseconds, strategy: :largest) == unit_for(:hour)
   end
 
   test ".best when list is mostly milliseconds, strategy: :none" do
-    assert best(@list_with_mostly_milliseconds, strategy: :none) == :microsecond
+    assert best(@list_with_mostly_milliseconds, strategy: :none) == unit_for(:microsecond)
   end
 end

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -3,10 +3,6 @@ defmodule Benchee.Conversion.DurationTest do
   import Benchee.Conversion.Duration
   doctest Benchee.Conversion.Duration
 
-  defp unit_for(unit_atom) do
-    Map.fetch! Benchee.Conversion.Duration.units, unit_atom
-  end
-
   test ".format(98.7654321)" do
     assert format(98.7654321) == "98.77 μs"
   end


### PR DESCRIPTION
This is the general PoC of what I meant/wanted to do. Instead
of passing `:billion`/`;thousand` etc. around let's use the
real units! I think this brings some benefits and I'd be intrigued
to see what @wasnotrice thinks. Pushing this for review, let's see
how much further I can take this :)

Seems like it could help get rid of some code

A PR based on a PR ( #40 ) that based on another PR... PRCeption!

Todo here:

- [x] Remove now not needed `module` arguments (such as `Format.format`)
- [x] see if we can remove some duplication (`unit_for` and other friends are used in both unit modules)
- [x] see if we still need `units` to be accessible, otherwise consider removing it
- [x] make doctests less brittle by using `name` to check against
- [x] Rework API so that `Benchee.Conversion.Count.format` can be used with a value and an atom representing the unit again