### PR TITLE
Allows labels to be atoms

### DIFF
--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -108,10 +108,16 @@ defmodule Benchee.Formatters.Console do
 
   defp label_width(jobs) do
     max_label_width = jobs
-      |> Enum.map(fn({job_name, _}) -> String.length(job_name) end)
+      |> Enum.map(&name_length/1)
       |> Stream.concat([@default_label_width])
       |> Enum.max
     max_label_width + 1
+  end
+
+  defp name_length({job_name, _}) do
+    job_name
+      |> to_string
+      |> String.length
   end
 
   defp job_reports(jobs, units, label_width) do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -268,6 +268,21 @@ defmodule Benchee.Formatters.ConsoleTest do
       ref_2 =~ ~r/Other Job/
       slower_2 =~ ~r/Job.+slower/
     end
+
+    test "allows atoms as labels" do
+      statistics = %{
+        arg: %{
+          experiment: %Statistics{
+            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+          }
+        }
+      }
+
+      [[header, _columns, data]] = Console.format(%Suite{statistics: statistics, configuration: @config})
+
+      assert header =~ ~r/arg/
+      assert data =~ ~r/experiment/
+    end
   end
 
   defp assert_column_width(name, string, expected_width) do


### PR DESCRIPTION
The formatting code was expecting the labels (map keys) to be strings. It would cause a confusing error if you use an atom.