### PR TITLE
Allows job labels to be atoms

### DIFF
--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -33,6 +33,7 @@ defmodule Benchee do
 
   defp do_run(jobs, config) do
     jobs
+    |> normalize_names
     |> run_benchmarks(config)
     |> output_results
   end
@@ -52,6 +53,12 @@ defmodule Benchee do
     end
 
     suite
+  end
+
+  defp normalize_names(jobs) do
+    for {key, fun} <- jobs, into: %{} do
+      {to_string(key), fun}
+    end
   end
 
   defdelegate init(),                                    to: Benchee.Configuration

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -253,6 +253,16 @@ defmodule BencheeTest do
     end
   end
 
+  test ".run accepts atom keys" do
+    capture_io fn ->
+      suite = Benchee.run(%{
+        sleep: fn -> :timer.sleep 1 end
+      }, time: 0.001, warmup: 0)
+
+      assert Map.keys(suite.jobs) == ~w(sleep)
+    end
+  end
+
   @slower_regex "\\s+- \\d+\\.\\d+x slower"
   defp readme_sample_asserts(output) do
     assert output =~ @header_regex


### PR DESCRIPTION
Allows job labels to be defined by atoms

As outlined in #83 

@PragTob Let me know if I have tests in the right place, or if it needs any changing!

Cheers!