### PR TITLE
WIP - Really rough implementation of calculating memory usage

### DIFF
--- a/lib/benchee/suite.ex
+++ b/lib/benchee/suite.ex
@@ -14,6 +14,7 @@ defmodule Benchee.Suite do
     :configuration,
     :system,
     :run_times,
+    :memory_usages,
     :statistics,
     jobs: %{}
   ]
@@ -25,6 +26,7 @@ defmodule Benchee.Suite do
     configuration: Benchee.Configuration.t | nil,
     system: optional_map,
     run_times: %{key => %{key => [integer]}} | nil,
+    memory_usages: %{key => %{key => [integer]}} | nil,
     statistics: %{key => %{key => Benchee.Statistics.t}} | nil,
     jobs: %{key => benchmark_function}
   }

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -52,9 +52,11 @@ defmodule Benchee.BenchmarkTest do
 
         assert new_suite.configuration == suite.configuration
         run_times_hash = new_suite.run_times |> no_input_access
+        memory_usage_hash = new_suite.memory_usages |> no_input_access
 
         # should be 6 but gotta give it a bit leeway
         assert length(run_times_hash["Name"]) >= 5
+        assert length(memory_usage_hash["Name"]) >= 5
       end
     end
 
@@ -68,11 +70,14 @@ defmodule Benchee.BenchmarkTest do
           |> measure(TestPrinter)
 
         run_times_hash = new_suite.run_times |> no_input_access
+        memory_usage_hash = new_suite.memory_usages |> no_input_access
 
         # should be 5 but gotta give it a bit leeway
         assert length(run_times_hash["Name"]) >= 4
+        assert length(memory_usage_hash["Name"]) >= 4
         # should be ~11, but gotta give it some leeway
         assert length(run_times_hash["Name 2"]) >= 8
+        assert length(memory_usage_hash["Name 2"]) >= 8
         end
     end
 
@@ -84,9 +89,11 @@ defmodule Benchee.BenchmarkTest do
       new_suite = measure suite, TestPrinter
 
       assert %{"" => run_times} = new_suite.run_times |> no_input_access
+      assert %{"" => memory_usages} = new_suite.memory_usages |> no_input_access
 
       # it does more work when working in parallel than it does alone
       assert length(run_times) >= 12
+      assert length(memory_usages) >= 12
     end
 
     test "doesn't take longer than advertised for very fast funs" do
@@ -201,12 +208,16 @@ defmodule Benchee.BenchmarkTest do
           %Suite{configuration: config, jobs: jobs}
           |> test_suite
           |> measure(TestPrinter)
-          |> Map.get(:run_times)
+
+        run_times = Map.get(results, :run_times)
+        memory_usages = Map.get(results, :memory_usages)
 
         # should be ~11 but the good old leeway
-        assert length(results["Short wait"]["sleep"]) >= 8
+        assert length(run_times["Short wait"]["sleep"]) >= 8
+        assert length(memory_usages["Short wait"]["sleep"]) >= 8
         # should be 5 but the good old leeway
-        assert length(results["Longer wait"]["sleep"]) >= 4
+        assert length(run_times["Longer wait"]["sleep"]) >= 4
+        assert length(memory_usages["Longer wait"]["sleep"]) >= 4
       end
     end
 


### PR DESCRIPTION
This adds in a non-breaking way to calculate memory usage. Right
now the actual calculation of the memory usage info is probably the
least good thing about this commit, since I'm seeing wildly varying
results (including negative memory usage) because of the inability to
turn off the GC. However, this is implemented in a way that changing
that calculation later on shouldn't require any further changes to what
we have here.

I'm putting this up now to get some preliminary feedback. I think the
testing is still really rough since I'm not yet sure _what_ we should be
testing and at what point since I don't really know what's important
about this new data. Any input on this would be helpful of course!

Next up is to do something with the results in the UI, and once we have
something rough there we can do some touchup work on this really naieve
implementation.