### PR TITLE
Add tests for error handling in `System.system_cmd`

### DIFF
--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -125,8 +125,8 @@ defmodule Benchee.System do
 
   defp format_memory(memory, coefficient), do: "#{memory / coefficient} GB"
 
-  defp system_cmd(cmd, args) do
-    {output, exit_code} = System.cmd(cmd, args)
+  def system_cmd(cmd, args, system_func \\ &System.cmd/2) do
+    {output, exit_code} = system_func.(cmd, args)
     if exit_code > 0 do
       IO.puts("Something went wrong trying to get system information:")
       IO.puts(output)

--- a/test/benchee/system_test.exs
+++ b/test/benchee/system_test.exs
@@ -2,6 +2,7 @@ defmodule Benchee.SystemTest do
   use ExUnit.Case, async: true
 
   alias Benchee.Suite
+  import ExUnit.CaptureIO
 
   test ".system adds the content to a given suite" do
     system_info = Benchee.System.system(%Suite{})
@@ -36,5 +37,16 @@ defmodule Benchee.SystemTest do
     {num, rest} = Float.parse(Benchee.System.available_memory())
     assert num > 0
     assert rest =~ ~r/GB/
+  end
+
+  test ".system_cmd handles errors gracefully" do
+    system_func = fn(_, _) -> {"ERROR", 1} end
+    captured_io = capture_io(fn ->
+      Benchee.System.system_cmd("cat", "dev/null", system_func)
+    end)
+
+    assert captured_io =~ "Something went wrong"
+    assert captured_io =~ "ERROR"
+    assert Benchee.System.system_cmd("cat", "dev/null", system_func) == "N/A"
   end
 end


### PR DESCRIPTION
I remembered that we wanted to add some tests for the error handling in
`Benchee.System.system_cmd/2`, so I went ahead and refactored that so
we could add those tests.