### PR TITLE
Allow atoms as names in jobs and inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features (User Facing)
 * Gather more system data like number of cores, Operating System, memory, cpu speed - thanks @devonestes and @OvermindDL1
+* the names for jobs in the map of `Benchee.run/2` or in `Benchee.benchmark/3` may now be given as strings or atoms - atoms will be converted to strings internally though for consistency and avoiding name duplicates
+* the names of inputs in the benchee configuration may now be given as strings or atoms - atoms will be converted to strings internally though for consistency and avoiding name duplicates
 
 # 0.8.0 (2017-05-07)
 

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -33,7 +33,6 @@ defmodule Benchee do
 
   defp do_run(jobs, config) do
     jobs
-    |> normalize_names
     |> run_benchmarks(config)
     |> output_results
   end
@@ -42,7 +41,7 @@ defmodule Benchee do
     config
     |> Benchee.init
     |> Benchee.system
-    |> Map.put(:jobs, jobs)
+    |> add_benchmarking_jobs(jobs)
     |> Benchee.measure
     |> Benchee.statistics
   end
@@ -55,9 +54,9 @@ defmodule Benchee do
     suite
   end
 
-  defp normalize_names(jobs) do
-    for {key, fun} <- jobs, into: %{} do
-      {to_string(key), fun}
+  defp add_benchmarking_jobs(suite, jobs) do
+    Enum.reduce jobs, suite, fn({key, function}, suite_acc) ->
+      Benchee.benchmark(suite_acc, key, function)
     end
   end
 

--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -18,11 +18,12 @@ defmodule Benchee.Benchmark do
   """
   @spec benchmark(Suite.t, name, fun, module) :: Suite.t
   def benchmark(suite = %Suite{jobs: jobs}, name, function, printer \\ Printer) do
-    if Map.has_key?(jobs, name) do
-      printer.duplicate_benchmark_warning name
+    normalized_name = to_string(name)
+    if Map.has_key?(jobs, normalized_name) do
+      printer.duplicate_benchmark_warning normalized_name
       suite
     else
-      %Suite{suite | jobs: Map.put(jobs, name, function)}
+      %Suite{suite | jobs: Map.put(jobs, normalized_name, function)}
     end
   end
 

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -18,6 +18,14 @@ defmodule Benchee.BenchmarkTest do
       assert new_suite == %Suite{jobs: %{"two" => two_fun, "one" => one_fun}}
     end
 
+    test "can add jobs with atom keys but converts them to string" do
+      suite = %Suite{}
+              |> benchmark("one job", fn -> 1 end)
+              |> benchmark(:something, fn -> 2 end)
+
+      assert %Suite{jobs: %{"one job" => _, "something" => _}} = suite
+    end
+
     test "warns when adding a job with the same name again" do
       one_fun = fn -> 1 end
       suite = %Suite{jobs: %{"one" => one_fun}}
@@ -26,6 +34,18 @@ defmodule Benchee.BenchmarkTest do
       assert new_suite == %Suite{jobs: %{"one" => one_fun}}
 
       assert_receive {:duplicate, "one"}
+    end
+
+    test "warns when adding the same job again even if it's atom and string" do
+      suite = %Suite{}
+              |> benchmark("something", fn -> 1 end, TestPrinter)
+              |> benchmark(:something, fn -> 2 end, TestPrinter)
+
+      assert %Suite{jobs: jobs}  =  suite
+      assert map_size(jobs)      == 1
+      assert %{"something" => _} = jobs
+      
+      assert_receive {:duplicate, "something"}
     end
   end
 

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -2,7 +2,7 @@ defmodule Benchee.ConfigurationTest do
   use ExUnit.Case, async: true
   doctest Benchee.Configuration
 
-  alias Benchee.Configuration
+  alias Benchee.{Configuration, Suite}
 
   import DeepMerge
   import Benchee.Configuration
@@ -14,6 +14,21 @@ defmodule Benchee.ConfigurationTest do
       assert_raise KeyError, fn ->
         init runntime: 2
       end
+    end
+
+    test "it converts input keys to strings" do
+      suite = init inputs: %{"map" => %{}, list: []}
+
+      assert %Suite{
+        configuration: %{inputs: %{"list" => [], "map" => %{}}}
+      } = suite
+    end
+
+    test "it loses duplicated inputs keys after normalization" do
+      suite = init inputs: %{"map" => %{}, map: %{}}
+
+      assert %Suite{configuration: %{inputs: inputs}} = suite
+      assert %{"map" => %{}} == inputs
     end
   end
 

--- a/test/benchee/system_test.exs
+++ b/test/benchee/system_test.exs
@@ -47,6 +47,8 @@ defmodule Benchee.SystemTest do
 
     assert captured_io =~ "Something went wrong"
     assert captured_io =~ "ERROR"
-    assert Benchee.System.system_cmd("cat", "dev/null", system_func) == "N/A"
+    capture_io fn ->
+      assert Benchee.System.system_cmd("cat", "dev/null", system_func) == "N/A"
+    end
   end
 end


### PR DESCRIPTION
Fixes #83 
Builds on #84 
Helps with #34 

Allow atoms but convert them to strings. Why? Because I really don't wanna see 2 things in the output that look exactly the same and not be able to distinguish them. Furthermore, for plugins it's better if they can consistently assume strings as the names for jobs and inputs and don't have to deal with atom shenanigans :)