### PR TITLE
WIP - Begin refactoring of Benchmark module

### DIFF
--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -1,15 +1,18 @@
 defmodule Benchee.Benchmark do
   @moduledoc """
-  Functionality related to the actual benchmarking. Meaning running the
+  Functionality related to the actual benchmarking. Meaning running the
   given functions and recording their individual run times in a list.
   Exposes `benchmark` function.
   """
 
-  alias Benchee.Utility.RepeatN
-  alias Benchee.Output.BenchmarkPrinter, as: Printer
   alias Benchee.Suite
+  alias Benchee.Benchmark.Runner
+  alias Benchee.Output.BenchmarkPrinter, as: Printer
 
   @type name :: String.t
+
+  defstruct [:name, :input, :input_name, :function, :printer, :config,
+             :run_times, :memory_usage]
 
   @doc """
   Adds the given function and its associated name to the benchmarking jobs to
@@ -44,152 +47,29 @@ defmodule Benchee.Benchmark do
   @spec measure(Suite.t, module) :: Suite.t
   def measure(suite = %Suite{jobs: jobs, configuration: config}, printer \\ Printer) do
     printer.configuration_information(suite)
-    run_times = record_runtimes(jobs, config, printer)
+    benchmarks = build_benchmarks(jobs, config, printer)
+    benchmarks_with_results = Runner.run_benchmarks(benchmarks)
 
-    %Suite{suite | run_times: run_times}
+    %Suite{suite | benchmarks: benchmarks_with_results}
   end
 
   @no_input :__no_input
   @no_input_marker {@no_input, @no_input}
-
-  @doc """
-  Key in the result for when there were no inputs given.
-  """
   def no_input, do: @no_input
 
-  defp record_runtimes(jobs, config = %{inputs: nil}, printer) do
-    [runtimes_for_input(@no_input_marker, jobs, config, printer)]
-    |> Map.new
+  defp build_benchmarks(jobs, config = %{inputs: nil}, printer) do
+    benchmarks_for_input(@no_input_marker, jobs, config, printer)
   end
-  defp record_runtimes(jobs, config = %{inputs: inputs}, printer) do
-    inputs
-    |> Enum.map(fn(input) ->
-         runtimes_for_input(input, jobs, config, printer)
-       end)
-    |> Map.new
+  defp build_benchmarks(jobs, config = %{inputs: inputs}, printer) do
+    Enum.flat_map(inputs, fn(input) ->
+      benchmarks_for_input(input, jobs, config, printer)
+    end)
   end
 
-  defp runtimes_for_input({input_name, input}, jobs, config, printer) do
-    printer.input_information(input_name, config)
-
-    results =
-      jobs
-      |> Enum.map(fn(job) -> measure_job(job, input, config, printer) end)
-      |> Map.new
-
-    {input_name, results}
-  end
-
-  defp measure_job({name, function}, input, config, printer) do
-    printer.benchmarking name, config
-    job_run_times = parallel_benchmark function, input, config, printer
-    {name, job_run_times}
-  end
-
-  defp parallel_benchmark(function,
-                          input,
-                          %{parallel: parallel,
-                            time:     time,
-                            warmup:   warmup,
-                            print:    %{fast_warning: fast_warning}},
-                          printer) do
-    pmap 1..parallel, fn ->
-      _ = run_warmup function, input, warmup, printer
-      measure_runtimes function, input, time, fast_warning, printer
-    end
-  end
-
-  defp pmap(collection, func) do
-    collection
-    |> Enum.map(fn(_) -> Task.async(func) end)
-    |> Enum.map(&Task.await(&1, :infinity))
-    |> List.flatten
-  end
-
-  defp run_warmup(function, input, time, printer) do
-    measure_runtimes(function, input, time, false, printer)
-  end
-
-  defp measure_runtimes(function, input, time, display_fast_warning, printer)
-  defp measure_runtimes(_function, _input, 0, _, _) do
-    []
-  end
-  defp measure_runtimes(function, input, time, display_fast_warning, printer) do
-    finish_time = current_time() + time
-    :erlang.garbage_collect
-    {n, initial_run_time} =
-      determine_n_times(function, input, display_fast_warning, printer)
-    do_benchmark(finish_time, function, input, [initial_run_time], n, current_time())
-  end
-
-  defp current_time do
-    :erlang.system_time :micro_seconds
-  end
-
-  # If a function executes way too fast measurements are too unreliable and
-  # with too high variance. Therefore determine an n how often it should be
-  # executed in the measurement cycle.
-  @minimum_execution_time 10
-  @times_multiplicator 10
-  defp determine_n_times(function, input, display_fast_warning, printer) do
-    run_time = measure_call function, input
-    if run_time >= @minimum_execution_time do
-      {1, run_time}
-    else
-      if display_fast_warning, do: printer.fast_warning()
-      try_n_times(function, input, @times_multiplicator)
-    end
-  end
-
-  defp try_n_times(function, input, n) do
-    run_time = measure_call_n_times function, input, n
-    if run_time >= @minimum_execution_time do
-      {n, run_time / n}
-    else
-      try_n_times(function, input, n * @times_multiplicator)
-    end
-  end
-
-  defp do_benchmark(finish_time, function, input, run_times, n, now)
-  defp do_benchmark(finish_time, _, _, run_times, _n, now)
-       when now > finish_time do
-    Enum.reverse run_times # restore correct order important for graphing
-  end
-  defp do_benchmark(finish_time, function, input, run_times, n, _now) do
-    run_time = measure_call(function, input, n)
-    updated_run_times = [run_time | run_times]
-    do_benchmark(finish_time, function, input,
-                 updated_run_times, n, current_time())
-  end
-
-  defp measure_call(function, input, n \\ 1)
-  defp measure_call(function, @no_input, 1) do
-    {microseconds, _return_value} = :timer.tc function
-    microseconds
-  end
-  defp measure_call(function, input, 1) do
-    {microseconds, _return_value} = :timer.tc function, [input]
-    microseconds
-  end
-  defp measure_call(function, input, n) do
-    measure_call_n_times(function, input, n) / n
-  end
-
-  defp measure_call_n_times(function, @no_input, n) do
-    {microseconds, _return_value} = :timer.tc fn ->
-      RepeatN.repeat_n(function, n)
-    end
-
-    microseconds
-  end
-  defp measure_call_n_times(function, input, n) do
-    call_with_arg = fn ->
-      function.(input)
-    end
-    {microseconds, _return_value} = :timer.tc fn ->
-      RepeatN.repeat_n(call_with_arg, n)
-    end
-
-    microseconds
+  defp benchmarks_for_input({input_name, input}, jobs, config, printer) do
+    Enum.map(jobs, fn({name, function}) ->
+      %__MODULE__{name: name, function: function, config: config,
+                  input_name: input_name, input: input, printer: printer}
+    end)
   end
 end

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -1,0 +1,121 @@
+defmodule Benchee.Benchmark.Runner do
+  @moduledoc """
+  This module is the runner for a given set of benchmarks. It runs the
+  benchmarks given, and returns benchmarks with the run times and memory usage
+  information for output.
+  """
+  alias Benchee.Utility.RepeatN
+  alias Benchee.Benchmark
+
+  @no_input :__no_input
+  def no_input, do: @no_input
+
+  def run_benchmarks(benchmarks) do
+    Enum.map(benchmarks, &parallel_benchmark/1)
+  end
+
+  defp parallel_benchmark(benchmark = %Benchmark{name: name,
+                                                 config: config,
+                                                 printer: printer}) do
+    printer.benchmarking name, config
+    pmap 1..config.parallel, fn ->
+      run_warmup(benchmark)
+      measure_runtimes(benchmark)
+    end
+  end
+
+  defp pmap(collection, func) do
+    collection
+    |> Enum.map(fn(_) -> Task.async(func) end)
+    |> Enum.map(&Task.await(&1, :infinity))
+    |> List.flatten
+  end
+
+  defp run_warmup(benchmark = %Benchmark{config: config}) do
+    print = Map.put(config.print, :fast_warning, false)
+    config = config |> Map.put(:print, print) |> Map.put(:time, config.warmup)
+    benchmark = %Benchmark{benchmark | config: config}
+    measure_runtimes(benchmark)
+  end
+
+  defp measure_runtimes(%Benchmark{config: %{time: 0}}), do: []
+  defp measure_runtimes(benchmark = %Benchmark{config: %{time: time}}) do
+    finish_time = current_time() + time
+    :erlang.garbage_collect
+    {n, initial_run_time} = determine_n_times(benchmark)
+    benchmark = %Benchmark{benchmark | run_times: [initial_run_time]}
+    do_benchmark(benchmark, n, current_time(), finish_time)
+  end
+
+  defp current_time do
+    :erlang.system_time :micro_seconds
+  end
+
+  # If a function executes way too fast measurements are too unreliable and
+  # with too high variance. Therefore determine an n how often it should be
+  # executed in the measurement cycle.
+  @minimum_execution_time 10
+  @times_multiplicator 10
+  defp determine_n_times(benchmark = %Benchmark{printer: printer, config: %{print: print}}) do
+    run_time = measure_call(benchmark)
+    if run_time >= @minimum_execution_time do
+      {1, run_time}
+    else
+      if print.fast_warning, do: printer.fast_warning()
+      try_n_times(benchmark, @times_multiplicator)
+    end
+  end
+
+  defp try_n_times(benchmark, n) do
+    run_time = measure_call_n_times(benchmark, n)
+    if run_time >= @minimum_execution_time do
+      {n, run_time / n}
+    else
+      try_n_times(benchmark, n * @times_multiplicator)
+    end
+  end
+
+  defp do_benchmark(benchmark, n, current_time, finish_time)
+  defp do_benchmark(benchmark = %Benchmark{run_times: run_times}, _, current_time, finish_time)
+    when current_time > finish_time do
+    # It is important for these to be in the correct order for graphing
+    ordered_run_times = Enum.reverse(run_times)
+    %Benchmark{benchmark | run_times: ordered_run_times}
+  end
+  defp do_benchmark(benchmark = %Benchmark{run_times: run_times}, n, _, finish_time) do
+    run_time = measure_call(benchmark, n)
+    benchmark = %Benchmark{run_times: [run_time | run_times]}
+    do_benchmark(benchmark, n, current_time(), finish_time)
+  end
+
+  defp measure_call(benchmark, n \\ 1)
+  defp measure_call(%Benchmark{function: function, input: @no_input}, 1) do
+    {microseconds, _return_value} = :timer.tc function
+    microseconds
+  end
+  defp measure_call(%Benchmark{function: function, input: input}, 1) do
+    {microseconds, _return_value} = :timer.tc function, [input]
+    microseconds
+  end
+  defp measure_call(benchmark, n) do
+    measure_call_n_times(benchmark, n) / n
+  end
+
+  defp measure_call_n_times(%Benchmark{function: function, input: @no_input}, n) do
+    {microseconds, _return_value} = :timer.tc fn ->
+      RepeatN.repeat_n(function, n)
+    end
+
+    microseconds
+  end
+  defp measure_call_n_times(%Benchmark{function: function, input: input}, n) do
+    call_with_arg = fn ->
+      function.(input)
+    end
+    {microseconds, _return_value} = :timer.tc fn ->
+      RepeatN.repeat_n(call_with_arg, n)
+    end
+
+    microseconds
+  end
+end

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -66,7 +66,7 @@ defmodule Benchee.Formatters.Console do
   end
 
   defp input_header(input) do
-    no_input_marker = Benchee.Benchmark.no_input
+    no_input_marker = Benchee.Benchmark.Runner.no_input()
     case input do
       ^no_input_marker -> ""
       _                -> "\n##### With input #{input} #####"

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -94,7 +94,7 @@ defmodule Benchee.Output.BenchmarkPrinter do
     nil
   end
   def input_information(input_name, _config) do
-    if input_name != Benchee.Benchmark.no_input do
+    if input_name != Benchee.Benchmark.Runner.no_input() do
       IO.puts "\nBenchmarking with input #{input_name}:"
     end
   end

--- a/lib/benchee/suite.ex
+++ b/lib/benchee/suite.ex
@@ -14,6 +14,7 @@ defmodule Benchee.Suite do
     :configuration,
     :system,
     :run_times,
+    :benchmarks,
     :statistics,
     jobs: %{}
   ]

--- a/lib/benchee/utility/file_creation.ex
+++ b/lib/benchee/utility/file_creation.ex
@@ -85,7 +85,7 @@ defmodule Benchee.Utility.FileCreation do
       ...>   ["Big Input", "Comparison", "great Stuff"])
       "bench/abc_big_input_comparison_great_stuff.csv"
 
-      iex> marker = Benchee.Benchmark.no_input
+      iex> marker = Benchee.Benchmark.Runner.no_input()
       iex> Benchee.Utility.FileCreation.interleave("abc.csv", marker)
       "abc.csv"
       iex> Benchee.Utility.FileCreation.interleave("abc.csv", [marker])
@@ -114,7 +114,7 @@ defmodule Benchee.Utility.FileCreation do
   end
 
   defp to_filename(name_string) do
-    no_input = Benchee.Benchmark.no_input
+    no_input = Benchee.Benchmark.Runner.no_input()
     case name_string do
       ^no_input -> ""
       _         ->

--- a/samples/formatters.exs
+++ b/samples/formatters.exs
@@ -3,7 +3,7 @@ map_fun = fn(i) -> [i, i * i] end
 
 format_fun = fn(%{run_times: run_times}) ->
   IO.puts ""
-  run_times = Map.get run_times, Benchee.Benchmark.no_input
+  run_times = Map.get run_times, Benchee.Benchmark.Runner.no_input()
   Enum.each run_times, fn({name, times}) ->
     IO.puts "Benchee recorded #{Enum.count times} run times for #{name}!"
   end

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -3,6 +3,7 @@ defmodule Benchee.BenchmarkTest do
   import Benchee.TestHelpers
   alias Benchee.Statistics
   alias Benchee.Benchmark
+  alias Benchee.Benchmark.Runner
   alias Benchee.Test.FakeBenchmarkPrinter, as: TestPrinter
   alias Benchee.Suite
   import Benchee.Benchmark
@@ -44,7 +45,7 @@ defmodule Benchee.BenchmarkTest do
       assert %Suite{jobs: jobs}  =  suite
       assert map_size(jobs)      == 1
       assert %{"something" => _} = jobs
-      
+
       assert_receive {:duplicate, "something"}
     end
   end
@@ -236,7 +237,7 @@ defmodule Benchee.BenchmarkTest do
         %Suite{configuration: %{time: 1_000, warmup: 0}, jobs: jobs}
         |> test_suite
         |> measure(TestPrinter)
-        |> get_in([Access.key!(:run_times), Benchmark.no_input, "Sleeps"])
+        |> get_in([Access.key!(:run_times), Runner.no_input(), "Sleeps"])
 
       assert length(run_times) == 1
     end
@@ -255,7 +256,7 @@ defmodule Benchee.BenchmarkTest do
           %Suite{configuration: %{time: 70_000, warmup: 0}, jobs: jobs}
           |> test_suite
           |> measure(TestPrinter)
-          |> get_in([Access.key!(:run_times), Benchmark.no_input, "Sleep more"])
+          |> get_in([Access.key!(:run_times), Runner.no_input(), "Sleep more"])
 
         assert length(run_times) >= 2 # should be 3 but good old leeway
         # as the function takes more time each time called run times should be

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Formatters.ConsoleTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureIO
-  import Benchee.Benchmark, only: [no_input: 0]
+  import Benchee.Benchmark.Runner, only: [no_input: 0]
   doctest Benchee.Formatters.Console
 
   alias Benchee.Formatters.Console

--- a/test/benchee/output/benchmark_printer_test.exs
+++ b/test/benchee/output/benchmark_printer_test.exs
@@ -118,7 +118,7 @@ defmodule Benchee.Output.BenchmarkPrintertest do
     end
 
     test "does nothing when it's the no input marker" do
-      marker = Benchee.Benchmark.no_input
+      marker = Benchee.Benchmark.Runner.no_input()
       output = capture_io fn ->
         input_information marker, %{}
       end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -16,5 +16,5 @@ defmodule Benchee.TestHelpers do
     end
   end
 
-  def no_input_access(map), do: map[Benchee.Benchmark.no_input]
+  def no_input_access(map), do: map[Benchee.Benchmark.Runner.no_input()]
 end


### PR DESCRIPTION
This is a non-functional, very early step in the process. I'm
just putting it up now to get some feedback before continuing. There
are a lot of things I still will need to work out.

While I was working on adding the memory usage information, it struck
me that it would be a lot easier to add that without major changes if
there was already a struct representing an individual benchmark that I
could add it to. I decided to explore this refactoring a bit, and after
this initial step I kind of like it.

Basically, I split the `Benchee.Benchmark` module into two parts -
`Benchee.Benchmark`, which handles creating the benchmark structs and
passing them along to the actual functions that will run the benchmarks,
and another module (`Benchee.Benchmark.Runner`) that handles the actual
running of the benchmarks.

So, what do folks think? It made sense to me since we already had a
struct for a `Suite` of benchmarks.