### PR TITLE
Add Benchmark.Scenario struct

### DIFF
--- a/lib/benchee/benchmark/scenario.ex
+++ b/lib/benchee/benchmark/scenario.ex
@@ -1,0 +1,15 @@
+defmodule Benchee.Benchmark.Scenario do
+  defstruct [:job_name, :function, :input_name, :input, :run_times,
+             :run_time_statistics, :memory_usages, :memory_usage_statistics]
+
+  @type t :: %__MODULE__{
+    job_name: binary,
+    function: fun,
+    input_name: binary | nil,
+    input: any | nil,
+    run_times: [float] | nil,
+    run_time_statistics: Benchee.Statistics.t | nil,
+    memory_usages: [non_neg_integer] | nil,
+    memory_usage_statistics: Benchee.Statistics.t | nil
+  }
+end

--- a/lib/benchee/suite.ex
+++ b/lib/benchee/suite.ex
@@ -15,7 +15,8 @@ defmodule Benchee.Suite do
     :system,
     :run_times,
     :statistics,
-    jobs: %{}
+    jobs: %{},
+    scenarios: []
   ]
 
   @type optional_map :: map | nil
@@ -26,7 +27,8 @@ defmodule Benchee.Suite do
     system: optional_map,
     run_times: %{key => %{key => [integer]}} | nil,
     statistics: %{key => %{key => Benchee.Statistics.t}} | nil,
-    jobs: %{key => benchmark_function}
+    jobs: %{key => benchmark_function},
+    scenarios: [] | [Benchee.Benchmark.Scenario.t]
   }
 end
 


### PR DESCRIPTION
This commit introduces a new struct representing a single thing to
benchmark, which we're calling a Scenario. A scenario represents a
combination of a function and an optional input (or inputs) for that
function. We will also store the results of the benchmark for the scenario
in this struct eventually. Right now the creation of these scenarios for
each job and each input is implemented and tested, but we're not actually
using them yet.