### PR TITLE
Add additional tests for System module

### DIFF
--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -78,12 +78,12 @@ defmodule Benchee.System do
   end
   def parse_cpu_for(:macOS, raw_output), do: String.trim(raw_output)
   def parse_cpu_for(:Linux, raw_output) do
-    Regex.run(~r/model name.*:([\w \(\)\-\@\.]*)/i, raw_output, capture: :all_but_first)
-    |> parse_cpu_for_(:Linux)
+    match_info = Regex.run(~r/model name.*:([\w \(\)\-\@\.]*)/i, raw_output, capture: :all_but_first)
+    case match_info do
+      [cpu_info] -> String.trim(cpu_info)
+      _          -> "Unrecognized processor"
+    end
   end
-
-  defp parse_cpu_for_(_cpu_info = nil,  :Linux), do: "Unrecognized processor"
-  defp parse_cpu_for_([cpu_info],       :Linux), do: String.trim(cpu_info)
 
   @doc """
   Returns an integer with the total number of available memory on the machine

--- a/test/benchee/system_test.exs
+++ b/test/benchee/system_test.exs
@@ -33,6 +33,18 @@ defmodule Benchee.SystemTest do
     assert Benchee.System.cpu_speed() =~ ~r/\d+.*hz/i
   end
 
+  test ".parse_cpu_for :Linux handles Semaphore CI output" do
+    semaphore_output = "model name	: Intel Core Processor (Haswell)"
+    output = Benchee.System.parse_cpu_for(:Linux, semaphore_output)
+    assert output =~ "Haswell"
+  end
+
+  test ".parse_cpu_for :Linux handles unknown architectures" do
+    raw_output = "Bender Bending Rodriguez"
+    output = Benchee.System.parse_cpu_for(:Linux, raw_output)
+    assert output == "Unrecognized processor"
+  end
+
   test ".available_memory returns the available memory on the computer" do
     {num, rest} = Float.parse(Benchee.System.available_memory())
     assert num > 0


### PR DESCRIPTION
As usual, after a bit of sleep I realized that the functions for
parsing the raw output from `system_cmd/2` was already there, and we
could test those in isolation without having to do much at all.

Resolves #104