### PR TITLE
Interpret system returned memory size as binary

### DIFF
--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -108,8 +108,8 @@ defmodule Benchee.System do
     parse_memory_for(:Linux, system_cmd("cat", ["/proc/meminfo"]))
   end
 
-  @kilobyte_to_gigabyte 1_000_000
-  @byte_to_gigabyte 1_000 * @kilobyte_to_gigabyte
+  @kilobyte_to_gigabyte 1024 * 1024
+  @byte_to_gigabyte 1024 * @kilobyte_to_gigabyte
 
   defp parse_memory_for(_, "N/A"), do: "N/A"
   defp parse_memory_for(:Windows, raw_output) do


### PR DESCRIPTION
This always irked, I think a binary representation is correct as
you know, computers.

The wikipedia article (https://en.wikipedia.org/wiki/Gigabyte)
also claims it:

However, the term is also used in some fields of computer science
and information technology to denote 1073741824 (1024^3 or 2^30)
bytes, particularly for sizes of RAM.

So, I think this is more correct. I also noted that we don't test
that particular part, but that might be for another day :)

-------------------

For reference, on master it claims (for me):

`Available memory: 16.372024 GB`

On this branch it claims:

`Available memory: 15.613578796386719 GB`

Which incidentally is the same my system info reports, no idea why though:

![selection_037](https://user-images.githubusercontent.com/606517/29285803-0de48494-8130-11e7-8ef9-c0d0c4b0e95c.png)


