### PR TITLE
Implement mode in Statistics calculation

### DIFF
--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -4,6 +4,8 @@ defmodule Benchee.Statistics do
   times and then compute statistics like the average and the standard devaition.
   """
 
+  alias Benchee.Statistics.Mode
+
   defstruct [:average, :ips, :std_dev, :std_dev_ratio, :std_dev_ips, :median,
              :mode, :minimum, :maximum, :sample_size]
 
@@ -66,6 +68,9 @@ defmodule Benchee.Statistics do
       value (or average of the two middle values when the number of times is
       even). More stable than the average and somewhat more likely to be a
       typical you see.
+    * mode          - the run time(s) that occur the most. Often one value, but
+      can be multiple values if they occur the same amount of times. If no value
+      occures at least twice, this value will be nil.
     * minimum       - the smallest (fastest) run time measured for the job
     * maximum       - the biggest (slowest) run time measured for the job
     * sample_size   - the number of run time measurements taken
@@ -155,7 +160,7 @@ defmodule Benchee.Statistics do
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
     median              = compute_median(run_times, iterations)
-    {mode, _mode_count} = compute_mode(run_times)
+    mode                = Mode.mode(run_times)
     minimum             = Enum.min run_times
     maximum             = Enum.max run_times
 
@@ -196,14 +201,6 @@ defmodule Benchee.Statistics do
     else
       (Enum.at(sorted, middle) + Enum.at(sorted, middle - 1)) / 2
     end
-  end
-
-  defp compute_mode(samples) do
-    samples
-    |> Enum.reduce(%{}, fn(sample, counts) ->
-         Map.update(counts, sample, 1, fn(old_value) -> old_value + 1 end)
-       end)
-    |> Enum.max_by(fn({_sample, occurences}) -> occurences end)
   end
 
   defp to_float(maybe_integer) do

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -5,7 +5,7 @@ defmodule Benchee.Statistics do
   """
 
   defstruct [:average, :ips, :std_dev, :std_dev_ratio, :std_dev_ips, :median,
-             :minimum, :maximum, :sample_size]
+             :mode, :minimum, :maximum, :sample_size]
 
   @type t :: %__MODULE__{
     average: float,
@@ -14,6 +14,7 @@ defmodule Benchee.Statistics do
     std_dev_ratio: float,
     std_dev_ips: float,
     median: number,
+    mode: number,
     minimum: number,
     maximum: number,
     sample_size: integer
@@ -100,6 +101,7 @@ defmodule Benchee.Statistics do
               std_dev_ratio: 0.4,
               std_dev_ips:   800.0,
               median:        450.0,
+              mode:          400,
               minimum:       200,
               maximum:       900,
               sample_size:   8
@@ -136,6 +138,7 @@ defmodule Benchee.Statistics do
         std_dev_ratio: 0.4,
         std_dev_ips:   800.0,
         median:        450.0,
+        mode:          400,
         minimum:       200,
         maximum:       900,
         sample_size:   8
@@ -152,6 +155,7 @@ defmodule Benchee.Statistics do
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
     median              = compute_median(run_times, iterations)
+    {mode, _mode_count} = compute_mode(run_times)
     minimum             = Enum.min run_times
     maximum             = Enum.max run_times
 
@@ -162,6 +166,7 @@ defmodule Benchee.Statistics do
       std_dev_ratio: standard_dev_ratio,
       std_dev_ips:   standard_dev_ips,
       median:        median,
+      mode:          mode,
       minimum:       minimum,
       maximum:       maximum,
       sample_size:   iterations
@@ -191,6 +196,14 @@ defmodule Benchee.Statistics do
     else
       (Enum.at(sorted, middle) + Enum.at(sorted, middle - 1)) / 2
     end
+  end
+
+  defp compute_mode(samples) do
+    samples
+    |> Enum.reduce(%{}, fn(sample, counts) ->
+         Map.update(counts, sample, 1, fn(old_value) -> old_value + 1 end)
+       end)
+    |> Enum.max_by(fn({_sample, occurences}) -> occurences end)
   end
 
   defp to_float(maybe_integer) do

--- a/lib/benchee/statistics/mode.ex
+++ b/lib/benchee/statistics/mode.ex
@@ -1,0 +1,50 @@
+defmodule Benchee.Statistics.Mode do
+  @moduledoc false
+
+  @doc """
+      iex> Benchee.Statistics.Mode.mode([5, 3, 4, 5, 1, 3, 1, 3])
+      3
+
+      iex> Benchee.Statistics.Mode.mode([])
+      nil
+
+      iex> Benchee.Statistics.Mode.mode([1, 2, 3, 4, 5])
+      nil
+
+      iex> mode = Benchee.Statistics.Mode.mode([5, 3, 4, 5, 1, 3, 1])
+      iex> Enum.sort(mode)
+      [1, 3, 5]
+  """
+  def mode(samples) do
+    samples
+    |> Enum.reduce(%{}, fn(sample, counts) ->
+         Map.update(counts, sample, 1, fn(old_value) -> old_value + 1 end)
+       end)
+    |> max_multiple
+    |> decide_mode
+  end
+
+  defp max_multiple(map) do
+    max_multiple(Enum.to_list(map), [{nil, 0}])
+  end
+
+  defp max_multiple([{sample, count} | rest], ref = [{_, max_count} | _]) do
+    new_ref = cond do
+                count < max_count  -> ref
+                count == max_count -> [{sample, count} | ref]
+                true               -> [{sample, count}]
+              end
+    max_multiple(rest, new_ref)
+  end
+  defp max_multiple([], ref) do
+    ref
+  end
+
+  defp decide_mode([{nil, _}]), do: nil
+  defp decide_mode([{_, 1} | _rest]), do: nil
+  defp decide_mode([{sample, _count}]), do: sample
+  defp decide_mode(multi_modes) do
+    Enum.map multi_modes, fn({sample, _}) -> sample end
+  end
+
+end

--- a/test/benchee/statistics/mode_test.exs
+++ b/test/benchee/statistics/mode_test.exs
@@ -1,0 +1,4 @@
+defmodule Benchee.Statistics.ModeTest do
+  use ExUnit.Case, async: true
+  doctest Benchee.Statistics.Mode
+end

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -67,8 +67,6 @@ defmodule Benchee.StatistcsTest do
       stats
     end
 
-    # no mode asserts in the sample asserts as the samples have no duplicated
-    # values and therefore mode isn't a useful value
     defp sample_1_asserts(stats) do
       assert stats.average == 394.0
       assert_in_delta stats.std_dev, 147.32, 0.01
@@ -78,6 +76,7 @@ defmodule Benchee.StatistcsTest do
       assert stats.minimum == 170
       assert stats.maximum == 600
       assert stats.sample_size == 5
+      assert stats.mode == nil
     end
 
     defp sample_2_asserts(stats) do
@@ -89,6 +88,7 @@ defmodule Benchee.StatistcsTest do
       assert stats.minimum == 7
       assert stats.maximum == 23
       assert stats.sample_size == 6
+      assert stats.mode == nil
     end
   end
 

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -40,6 +40,16 @@ defmodule Benchee.StatistcsTest do
       sample_2_asserts(stats_2)
     end
 
+    @mode_sample [55, 40, 67, 55, 44, 40, 10, 8, 55, 90, 67]
+    test "mode is calculated correctly" do
+      scenarios = [%Scenario{run_times: @mode_sample}]
+      suite = %Suite{scenarios: scenarios}
+              |> Statistics.statistics
+
+      [%Scenario{run_time_statistics: stats}] = suite.scenarios
+      assert stats.mode == 55
+    end
+
     test "preserves all other keys in the map handed to it" do
       suite = %Suite{
         scenarios: [],
@@ -57,6 +67,8 @@ defmodule Benchee.StatistcsTest do
       stats
     end
 
+    # no mode asserts in the sample asserts as the samples have no duplicated
+    # values and therefore mode isn't a useful value
     defp sample_1_asserts(stats) do
       assert stats.average == 394.0
       assert_in_delta stats.std_dev, 147.32, 0.01


### PR DESCRIPTION
Another nice statistics to have handy. Imo could be very useful
for memory measuremnts as I hope that memory usage will often be
very stable so getting the mode should be close to the actual
memory usage.

We also get the `mode_count` for "free` not sure if we should
include it or not (I have never seen it used), but it seems sort
of useful (like for memory usages we could say/include stuff like
60% of all samples were this that helps)