### PR TITLE
Define behaviour for a formatter and output in parallel

### DIFF
--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -1,0 +1,28 @@
+defmodule Benchee.Formatter do
+  @moduledoc """
+  Defines a behaviour for formatters in Benchee, and also defines functions to
+  handle invoking that defined behavior.
+  """
+
+  alias Benchee.{Suite, Utility.Parallel}
+
+  @callback output(Suite.t) :: Suite.t
+  @callback format(Suite.t) :: any
+  @callback write(any) :: :ok | {:error, String.t}
+
+  @doc """
+  Invokes `format/1` and `write/1` as defined by the `Benchee.Formatter`
+  behaviour. The output for all formatters are generated in parallel, and then
+  the results of that formatting are written in sequence.
+  """
+  @spec parallel_output(Suite.t, [module]) :: Suite.t
+  def parallel_output(suite, modules) do
+    modules
+    |> Parallel.map(fn(module) ->
+         {module, module.format(suite)}
+       end)
+    |> Enum.each(fn({module, output}) -> module.write(output) end)
+
+    suite
+  end
+end

--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -18,9 +18,7 @@ defmodule Benchee.Formatter do
   @spec parallel_output(Suite.t, [module]) :: Suite.t
   def parallel_output(suite, modules) do
     modules
-    |> Parallel.map(fn(module) ->
-         {module, module.format(suite)}
-       end)
+    |> Parallel.map(fn(module) -> {module, module.format(suite)} end)
     |> Enum.each(fn({module, output}) -> module.write(output) end)
 
     suite

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -4,6 +4,8 @@ defmodule Benchee.Formatters.Console do
   output through `IO.write` on the console.
   """
 
+  @behaviour Benchee.Formatter
+
   alias Benchee.{Statistics, Suite, Benchmark.Scenario}
   alias Benchee.Conversion.{Count, Duration, Unit, DeviationPercent}
 
@@ -21,9 +23,9 @@ defmodule Benchee.Formatters.Console do
   """
   @spec output(Suite.t) :: Suite.t
   def output(suite = %Suite{}) do
-    suite
-    |> format
-    |> IO.write
+    _ = suite
+        |> format
+        |> write
 
     suite
   end
@@ -74,6 +76,16 @@ defmodule Benchee.Formatters.Console do
     |> Enum.map(fn({input, scenarios}) ->
         [input_header(input) | format_scenarios(scenarios, config)]
       end)
+  end
+
+  @doc """
+  Takes the output of `format/1` and writes that to the console.
+  """
+  @spec write(any) :: :ok | {:error, String.t}
+  def write(output) do
+    IO.write(output)
+  rescue
+    _ -> {:error, "Unknown Error"}
   end
 
   @no_input_marker Benchee.Benchmark.no_input()

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -23,9 +23,9 @@ defmodule Benchee.Formatters.Console do
   """
   @spec output(Suite.t) :: Suite.t
   def output(suite = %Suite{}) do
-    _ = suite
-        |> format
-        |> write
+    :ok = suite
+          |> format
+          |> write
 
     suite
   end

--- a/test/benchee/formatter_test.exs
+++ b/test/benchee/formatter_test.exs
@@ -1,0 +1,17 @@
+defmodule Benchee.FormatterTest do
+  use ExUnit.Case, async: true
+  alias Benchee.{Suite, Formatter, Test.FakeFormatter}
+
+  @suite %Suite{}
+  describe "parallel_output/2" do
+    test "calls `write/1` with the output of `format/1` on each module" do
+      Formatter.parallel_output(@suite, [FakeFormatter])
+
+      assert_receive {:write, "output of `format/1`"}
+    end
+
+    test "returns the suite passed in as the first argument unchanged" do
+      assert Formatter.parallel_output(@suite, [FakeFormatter]) == @suite
+    end
+  end
+end

--- a/test/support/fake_formatter.ex
+++ b/test/support/fake_formatter.ex
@@ -1,0 +1,9 @@
+defmodule Benchee.Test.FakeFormatter do
+  def format(_) do
+    "output of `format/1`"
+  end
+
+  def write(output) do
+    send self(), {:write, output}
+  end
+end


### PR DESCRIPTION
In this commit I'm defining a behaviour for a Benchee Formatter, which
consistes of three functions:

* format/1 which takes a Benchee.Suite struct and formats results
* write/1 which takes the output from format/1 and writes it either to
a file or to the console, and
* output/1 which basically just calls `format/1` and then `write/1` and
returns the Benchee.Suite struct it was given.

I don't see why we can't eventually remove the `output/1` callback from
this behaviour once we've switched over to using `parallel_output/2`
and once we've implemented this behaviour in all the other formatters.

I also wrote a function that can do as much in parallel as possible for
formatting. We can't write the output in parallel, but we can generate
the output in parallel, so we're doing that here.

I haven't switched over to actually using this new function to do the
formatting in parallel, but we can do that in a later commit.

Resolves #53