### PR TITLE
before/after_scenario implementation

### DIFF
--- a/lib/benchee/benchmark/scenario.ex
+++ b/lib/benchee/benchmark/scenario.ex
@@ -19,7 +19,9 @@ defmodule Benchee.Benchmark.Scenario do
     run_times: [],
     memory_usages: [],
     before_each: nil,
-    after_each: nil
+    after_each: nil,
+    before_scenario: nil,
+    after_scenario: nil
   ]
 
   @type t :: %__MODULE__{
@@ -32,6 +34,8 @@ defmodule Benchee.Benchmark.Scenario do
     memory_usages: [non_neg_integer] | [],
     memory_usage_statistics: Benchee.Statistics.t | nil,
     before_each: fun | nil,
-    after_each: fun | nil
+    after_each: fun | nil,
+    before_scenario: fun | nil,
+    after_scenario: fun | nil
   }
 end

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -33,7 +33,9 @@ defmodule Benchee.Configuration do
     # If you/your plugin/whatever needs it your data can go here
     assigns:           %{},
     before_each:       nil,
-    after_each:        nil
+    after_each:        nil,
+    before_scenario:   nil,
+    after_scenario:    nil
   ]
 
   @type t :: %__MODULE__{
@@ -46,7 +48,9 @@ defmodule Benchee.Configuration do
     formatter_options: map,
     assigns:           map,
     before_each:       fun | nil,
-    after_each:        fun | nil
+    after_each:        fun | nil,
+    before_scenario:   fun | nil,
+    after_scenario:    fun | nil
   }
 
   @type user_configuration :: map | keyword
@@ -135,7 +139,9 @@ defmodule Benchee.Configuration do
             },
             assigns: %{},
             before_each: nil,
-            after_each: nil
+            after_each: nil,
+            before_scenario: nil,
+            after_scenario: nil
           },
         system: nil,
         scenarios: []
@@ -160,7 +166,9 @@ defmodule Benchee.Configuration do
             },
             assigns: %{},
             before_each: nil,
-            after_each: nil
+            after_each: nil,
+            before_scenario: nil,
+            after_scenario: nil
           },
         system: nil,
         scenarios: []
@@ -185,7 +193,9 @@ defmodule Benchee.Configuration do
             },
             assigns: %{},
             before_each: nil,
-            after_each: nil
+            after_each: nil,
+            before_scenario: nil,
+            after_scenario: nil
           },
         system: nil,
         scenarios: []
@@ -219,7 +229,9 @@ defmodule Benchee.Configuration do
             },
             assigns: %{},
             before_each: nil,
-            after_each: nil
+            after_each: nil,
+            before_scenario: nil,
+            after_scenario: nil
           },
         system: nil,
         scenarios: []

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -54,17 +54,20 @@ defmodule Benchee.BenchmarkTest do
     end
 
     test "can deal with the options tuple" do
-      function = fn -> 1 end
-      before   = fn -> 2 end
+      function       = fn -> 1 end
+      before         = fn -> 2 end
+      after_scenario = fn -> 3 end
       suite =
         %Suite{}
-        |> Benchmark.benchmark("job", {function, before_each: before})
+        |> Benchmark.benchmark("job", {
+          function, before_each: before, after_scenario: after_scenario})
 
       [scenario] = suite.scenarios
       assert %{
         job_name: "job",
         function: ^function,
-        before_each: ^before } = scenario
+        before_each: ^before,
+        after_scenario: ^after_scenario } = scenario
     end
   end
 


### PR DESCRIPTION
before/after_scenario run exactly like they say before/after that
scenario - meaning before the warmup and after running the
measurements of all the iterations.

Actual implementation is pretty simple, honestly test took more time/work :) Btw. personally love how clear the code looks with that inserted, easy to see what happens when imo :)

#59 