### PR TITLE
before_scenario is passed the input and can return a different one

### DIFF
--- a/lib/benchee/benchmark/scenario_context.ex
+++ b/lib/benchee/benchmark/scenario_context.ex
@@ -8,6 +8,7 @@ defmodule Benchee.Benchmark.ScenarioContext do
     :current_time,
     :end_time,
     :benchmarking_function,
+    :scenario_input, # before_scenario can alter the original input
     num_iterations: 1
   ]
 
@@ -17,6 +18,7 @@ defmodule Benchee.Benchmark.ScenarioContext do
     current_time:          pos_integer | nil,
     end_time:              pos_integer | nil,
     benchmarking_function: (() -> any) | nil,
+    scenario_input:        any,
     num_iterations:        pos_integer
   }
 end

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -332,14 +332,20 @@ defmodule BencheeTest do
             fn -> :timer.sleep 1 end,
             before_each: fn -> send myself, :local_before end,
             after_each:  fn(_) -> send myself, :local_after end,
-            before_scenario: fn -> send myself, :local_before_scenario end,
+            before_scenario: fn(input) ->
+              send myself, :local_before_scenario
+              input
+            end,
             after_scenario: fn -> send myself, :local_after_scenario end},
           "sleeper 2" => fn -> :timer.sleep 1 end
         }, time: 0.0001,
            warmup: 0,
            before_each: fn -> send myself, :global_before end,
            after_each:  fn(_) -> send myself, :global_after end,
-           before_scenario: fn -> send myself, :global_before_scenario end,
+           before_scenario: fn(input) ->
+             send myself, :global_before_scenario
+             input
+           end,
            after_scenario:  fn -> send myself, :global_after_scenario end
       end
 


### PR DESCRIPTION
Introduced a new `scenario_input` field to keep the value around
as long as we need it as the hooks are run exactly once for each
scenario. Contemplated just naming it `input` but decided it was
too difficult.

As a side effect, creation of the benchmarking function had to be
moved around. It's closer to where it will be used now, which is
good. However, once we pass this on to `before/after_each` there
is a strong possibility it might change as well (as the inputs can
change again).