### PR TITLE
Format according to new formatter rules in 1.6

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,9 @@
+[
+  inputs: [
+    "lib/**/*.{ex,exs}",
+    "test/**/*.{ex,exs}",
+    "mix/**/*.{ex,exs}",
+    "mix.exs"
+  ],
+  locals_without_parens: []
+]

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -36,9 +36,11 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
 
     """
     def run(jobs, config \\ [])
+
     def run(jobs, config) when is_list(config) do
       do_run(jobs, config)
     end
+
     def run(config, jobs) when is_map(jobs) do
       # pre 0.6.0 way of passing in the config first and as a map
       do_run(jobs, config)
@@ -52,34 +54,32 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
 
     defp run_benchmarks(jobs, config) do
       config
-      |> Benchee.init
-      |> Benchee.system
+      |> Benchee.init()
+      |> Benchee.system()
       |> add_benchmarking_jobs(jobs)
-      |> Benchee.measure
-      |> Benchee.statistics
+      |> Benchee.measure()
+      |> Benchee.statistics()
     end
 
     defp output_results(suite = %{configuration: %{formatters: formatters}}) do
-      Enum.each formatters, fn(output_function) ->
-        output_function.(suite)
-      end
+      Enum.each(formatters, fn output_function -> output_function.(suite) end)
 
       suite
     end
 
     defp add_benchmarking_jobs(suite, jobs) do
-      Enum.reduce jobs, suite, fn({key, function}, suite_acc) ->
+      Enum.reduce(jobs, suite, fn {key, function}, suite_acc ->
         Benchee.benchmark(suite_acc, key, function)
-      end
+      end)
     end
 
-    defdelegate init(),                           to: Benchee.Configuration
-    defdelegate init(config),                     to: Benchee.Configuration
-    defdelegate system(suite),                    to: Benchee.System
-    defdelegate measure(suite),                   to: Benchee.Benchmark
-    defdelegate measure(suite, printer),          to: Benchee.Benchmark
-    defdelegate benchmark(suite, name, function), to: Benchee.Benchmark
-    defdelegate statistics(suite),                to: Benchee.Statistics
-    defdelegate benchmark(suite, name, function, printer), to: Benchee.Benchmark
+    defdelegate(init(), to: Benchee.Configuration)
+    defdelegate(init(config), to: Benchee.Configuration)
+    defdelegate(system(suite), to: Benchee.System)
+    defdelegate(measure(suite), to: Benchee.Benchmark)
+    defdelegate(measure(suite, printer), to: Benchee.Benchmark)
+    defdelegate(benchmark(suite, name, function), to: Benchee.Benchmark)
+    defdelegate(statistics(suite), to: Benchee.Statistics)
+    defdelegate(benchmark(suite, name, function, printer), to: Benchee.Benchmark)
   end
 end

--- a/lib/benchee/benchmark/scenario.ex
+++ b/lib/benchee/benchmark/scenario.ex
@@ -25,17 +25,17 @@ defmodule Benchee.Benchmark.Scenario do
   ]
 
   @type t :: %__MODULE__{
-    job_name: binary,
-    function: fun,
-    input_name: binary | nil,
-    input: any | nil,
-    run_times: [float] | [],
-    run_time_statistics: Benchee.Statistics.t | nil,
-    memory_usages: [non_neg_integer] | [],
-    memory_usage_statistics: Benchee.Statistics.t | nil,
-    before_each: fun | nil,
-    after_each: fun | nil,
-    before_scenario: fun | nil,
-    after_scenario: fun | nil
-  }
+          job_name: binary,
+          function: fun,
+          input_name: binary | nil,
+          input: any | nil,
+          run_times: [float] | [],
+          run_time_statistics: Benchee.Statistics.t() | nil,
+          memory_usages: [non_neg_integer] | [],
+          memory_usage_statistics: Benchee.Statistics.t() | nil,
+          before_each: fun | nil,
+          after_each: fun | nil,
+          before_scenario: fun | nil,
+          after_scenario: fun | nil
+        }
 end

--- a/lib/benchee/benchmark/scenario_context.ex
+++ b/lib/benchee/benchmark/scenario_context.ex
@@ -12,11 +12,11 @@ defmodule Benchee.Benchmark.ScenarioContext do
   ]
 
   @type t :: %__MODULE__{
-    config:                Benchee.Configuration.t,
-    printer:               module,
-    current_time:          pos_integer | nil,
-    end_time:              pos_integer | nil,
-    benchmarking_function: (() -> any) | nil,
-    num_iterations:        pos_integer
-  }
+          config: Benchee.Configuration.t(),
+          printer: module,
+          current_time: pos_integer | nil,
+          end_time: pos_integer | nil,
+          benchmarking_function: (-> any) | nil,
+          num_iterations: pos_integer
+        }
 end

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -4,54 +4,52 @@ defmodule Benchee.Configuration do
   """
 
   alias Benchee.{
-    Suite,
-    Configuration,
-    Conversion.Duration,
-    Utility.DeepConvert,
-    Formatters.Console
-  }
+          Suite,
+          Configuration,
+          Conversion.Duration,
+          Utility.DeepConvert,
+          Formatters.Console
+        }
 
-  defstruct [
-    parallel:          1,
-    time:              5,
-    warmup:            2,
-    formatters:        [&Console.output/1],
-    print: %{
-      benchmarking:    true,
-      configuration:   true,
-      fast_warning:    true
-    },
-    inputs:            nil,
-    # formatters should end up here but known once are still picked up at
-    # the top level for now
-    formatter_options: %{
-      console: %{
-        comparison:    true,
-        unit_scaling:  :best
-      }
-    },
-    # If you/your plugin/whatever needs it your data can go here
-    assigns:           %{},
-    before_each:       nil,
-    after_each:        nil,
-    before_scenario:   nil,
-    after_scenario:    nil
-  ]
+  # formatters should end up here but known once are still picked up at
+  # the top level for now
+  # If you/your plugin/whatever needs it your data can go here
+  defstruct parallel: 1,
+            time: 5,
+            warmup: 2,
+            formatters: [&Console.output/1],
+            print: %{
+              benchmarking: true,
+              configuration: true,
+              fast_warning: true
+            },
+            inputs: nil,
+            formatter_options: %{
+              console: %{
+                comparison: true,
+                unit_scaling: :best
+              }
+            },
+            assigns: %{},
+            before_each: nil,
+            after_each: nil,
+            before_scenario: nil,
+            after_scenario: nil
 
   @type t :: %__MODULE__{
-    parallel:          integer,
-    time:              number,
-    warmup:            number,
-    formatters:        [((Suite.t) -> Suite.t)],
-    print:             map,
-    inputs:            %{Suite.key => any} | nil,
-    formatter_options: map,
-    assigns:           map,
-    before_each:       fun | nil,
-    after_each:        fun | nil,
-    before_scenario:   fun | nil,
-    after_scenario:    fun | nil
-  }
+          parallel: integer,
+          time: number,
+          warmup: number,
+          formatters: [(Suite.t() -> Suite.t())],
+          print: map,
+          inputs: %{Suite.key() => any} | nil,
+          formatter_options: map,
+          assigns: map,
+          before_each: fun | nil,
+          after_each: fun | nil,
+          before_scenario: fun | nil,
+          after_scenario: fun | nil
+        }
 
   @type user_configuration :: map | keyword
   @time_keys [:time, :warmup]
@@ -237,21 +235,22 @@ defmodule Benchee.Configuration do
         scenarios: []
       }
   """
-  @spec init(user_configuration) :: Suite.t
+  @spec init(user_configuration) :: Suite.t()
   def init(config \\ %{}) do
-    :ok    = :timer.start
+    :ok = :timer.start()
 
-    config = config
-             |> standardized_user_configuration
-             |> merge_with_defaults
-             |> convert_time_to_micro_s
+    config =
+      config
+      |> standardized_user_configuration
+      |> merge_with_defaults
+      |> convert_time_to_micro_s
 
     %Suite{configuration: config}
   end
 
   defp standardized_user_configuration(config) do
     config
-    |> DeepConvert.to_map
+    |> DeepConvert.to_map()
     |> translate_formatter_keys
     |> force_string_input_keys
   end
@@ -260,16 +259,19 @@ defmodule Benchee.Configuration do
   # formatter_options now
   @formatter_keys [:console, :csv, :json, :html]
   defp translate_formatter_keys(config) do
-      {formatter_options, config} = Map.split(config, @formatter_keys)
+    {formatter_options, config} = Map.split(config, @formatter_keys)
     DeepMerge.deep_merge(%{formatter_options: formatter_options}, config)
   end
 
   defp force_string_input_keys(config = %{inputs: inputs}) do
-    standardized_inputs = for {name, value} <- inputs, into: %{} do
-                            {to_string(name), value}
-                          end
+    standardized_inputs =
+      for {name, value} <- inputs, into: %{} do
+        {to_string(name), value}
+      end
+
     %{config | inputs: standardized_inputs}
   end
+
   defp force_string_input_keys(config), do: config
 
   defp merge_with_defaults(user_config) do
@@ -277,12 +279,14 @@ defmodule Benchee.Configuration do
   end
 
   defp convert_time_to_micro_s(config) do
-    Enum.reduce @time_keys, config, fn(key, new_config) ->
-      {_, new_config} = Map.get_and_update! new_config, key, fn(seconds) ->
-        {seconds, Duration.microseconds({seconds, :second})}
-      end
+    Enum.reduce(@time_keys, config, fn key, new_config ->
+      {_, new_config} =
+        Map.get_and_update!(new_config, key, fn seconds ->
+          {seconds, Duration.microseconds({seconds, :second})}
+        end)
+
       new_config
-    end
+    end)
   end
 end
 
@@ -290,8 +294,9 @@ defimpl DeepMerge.Resolver, for: Benchee.Configuration do
   def resolve(_original, override = %{__struct__: Benchee.Configuration}, _) do
     override
   end
+
   def resolve(original, override, resolver) when is_map(override) do
     merged = Map.merge(original, override, resolver)
-    struct! Benchee.Configuration, Map.to_list(merged)
+    struct!(Benchee.Configuration, Map.to_list(merged))
   end
 end

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -10,33 +10,33 @@ defmodule Benchee.Conversion.Count do
 
   @one_billion 1_000_000_000
   @one_million 1_000_000
-  @one_thousand 1_000
+  @one_thousand 1000
 
   @units %{
-    billion:  %Unit{
-                name:      :billion,
-                magnitude: @one_billion,
-                label:     "B",
-                long:      "Billion"
-              },
-    million:  %Unit{
-                name:      :million,
-                magnitude: @one_million,
-                label:     "M",
-                long:      "Million"
-              },
+    billion: %Unit{
+      name: :billion,
+      magnitude: @one_billion,
+      label: "B",
+      long: "Billion"
+    },
+    million: %Unit{
+      name: :million,
+      magnitude: @one_million,
+      label: "M",
+      long: "Million"
+    },
     thousand: %Unit{
-                name:      :thousand,
-                magnitude: @one_thousand,
-                label:     "K",
-                long:      "Thousand"
-              },
-    one:      %Unit{
-                name:      :one,
-                magnitude: 1,
-                label:     "",
-                long:      ""
-              },
+      name: :thousand,
+      magnitude: @one_thousand,
+      label: "K",
+      long: "Thousand"
+    },
+    one: %Unit{
+      name: :one,
+      magnitude: 1,
+      label: "",
+      long: ""
+    }
   }
 
   @doc """
@@ -60,12 +60,15 @@ defmodule Benchee.Conversion.Count do
   def scale(count) when count >= @one_billion do
     scale_with_unit(count, :billion)
   end
+
   def scale(count) when count >= @one_million do
     scale_with_unit(count, :million)
   end
+
   def scale(count) when count >= @one_thousand do
     scale_with_unit(count, :thousand)
   end
+
   def scale(count) do
     scale_with_unit(count, :one)
   end
@@ -89,7 +92,7 @@ defmodule Benchee.Conversion.Count do
       }
   """
   def unit_for(unit) do
-    Scale.unit_for @units, unit
+    Scale.unit_for(@units, unit)
   end
 
   @doc """
@@ -111,7 +114,7 @@ defmodule Benchee.Conversion.Count do
 
   """
   def scale(count, unit) do
-    Scale.scale count, unit, __MODULE__
+    Scale.scale(count, unit, __MODULE__)
   end
 
   @doc """
@@ -137,6 +140,7 @@ defmodule Benchee.Conversion.Count do
 
   """
   def best(list, opts \\ [strategy: :best])
+
   def best(list, opts) do
     Scale.best_unit(list, __MODULE__, opts)
   end

--- a/lib/benchee/conversion/deviation_percent.ex
+++ b/lib/benchee/conversion/deviation_percent.ex
@@ -1,5 +1,4 @@
 defmodule Benchee.Conversion.DeviationPercent do
-
   @moduledoc """
   Helps with formattiong for the standard deviation ratio converting it into the
   more common percent form.

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -12,42 +12,41 @@ defmodule Benchee.Conversion.Duration do
   @milliseconds_per_second 1000
   @seconds_per_minute 60
   @minutes_per_hour 60
-  @microseconds_per_second @microseconds_per_millisecond *
-    @milliseconds_per_second
+  @microseconds_per_second @microseconds_per_millisecond * @milliseconds_per_second
   @microseconds_per_minute @microseconds_per_second * @seconds_per_minute
   @microseconds_per_hour @microseconds_per_minute * @minutes_per_hour
 
   @units %{
-    hour:        %Unit{
-                    name:      :hour,
-                    magnitude: @microseconds_per_hour,
-                    label:     "h",
-                    long:      "Hours"
-                 },
-    minute:      %Unit{
-                    name:      :minute,
-                    magnitude: @microseconds_per_minute,
-                    label:     "min",
-                    long:      "Minutes"
-                 },
-    second:      %Unit{
-                    name:      :second,
-                    magnitude: @microseconds_per_second,
-                    label:     "s",
-                    long:      "Seconds"
-                 },
+    hour: %Unit{
+      name: :hour,
+      magnitude: @microseconds_per_hour,
+      label: "h",
+      long: "Hours"
+    },
+    minute: %Unit{
+      name: :minute,
+      magnitude: @microseconds_per_minute,
+      label: "min",
+      long: "Minutes"
+    },
+    second: %Unit{
+      name: :second,
+      magnitude: @microseconds_per_second,
+      label: "s",
+      long: "Seconds"
+    },
     millisecond: %Unit{
-                    name:      :millisecond,
-                    magnitude: @microseconds_per_millisecond,
-                    label:     "ms",
-                    long:      "Milliseconds"
-                 },
+      name: :millisecond,
+      magnitude: @microseconds_per_millisecond,
+      label: "ms",
+      long: "Milliseconds"
+    },
     microsecond: %Unit{
-                    name:      :microsecond,
-                    magnitude: 1,
-                    label:     "μs",
-                    long:      "Microseconds"
-                 }
+      name: :microsecond,
+      magnitude: 1,
+      label: "μs",
+      long: "Microseconds"
+    }
   }
 
   @doc """
@@ -74,19 +73,23 @@ defmodule Benchee.Conversion.Duration do
       :hour
   """
   def scale(duration) when duration >= @microseconds_per_hour do
-    scale_with_unit duration, :hour
+    scale_with_unit(duration, :hour)
   end
+
   def scale(duration) when duration >= @microseconds_per_minute do
-    scale_with_unit duration, :minute
+    scale_with_unit(duration, :minute)
   end
+
   def scale(duration) when duration >= @microseconds_per_second do
-    scale_with_unit duration, :second
+    scale_with_unit(duration, :second)
   end
+
   def scale(duration) when duration >= @microseconds_per_millisecond do
-    scale_with_unit duration, :millisecond
+    scale_with_unit(duration, :millisecond)
   end
+
   def scale(duration) do
-    scale_with_unit duration, :microsecond
+    scale_with_unit(duration, :microsecond)
   end
 
   # Helper function for returning a tuple of {value, unit}
@@ -108,7 +111,7 @@ defmodule Benchee.Conversion.Duration do
       }
   """
   def unit_for(unit) do
-    Scale.unit_for @units, unit
+    Scale.unit_for(@units, unit)
   end
 
   @doc """
@@ -127,7 +130,7 @@ defmodule Benchee.Conversion.Duration do
 
   """
   def scale(count, unit) do
-    Scale.scale count, unit, __MODULE__
+    Scale.scale(count, unit, __MODULE__)
   end
 
   @doc """
@@ -148,8 +151,9 @@ defmodule Benchee.Conversion.Duration do
   def microseconds({duration, %Unit{magnitude: magnitude}}) do
     duration * magnitude
   end
+
   def microseconds({duration, unit_atom}) do
-    microseconds {duration, unit_for(unit_atom)}
+    microseconds({duration, unit_for(unit_atom)})
   end
 
   @doc """
@@ -174,6 +178,7 @@ defmodule Benchee.Conversion.Duration do
       :second
   """
   def best(list, opts \\ [strategy: :best])
+
   def best(list, opts) do
     Scale.best_unit(list, __MODULE__, opts)
   end

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -12,7 +12,7 @@ defmodule Benchee.Conversion.Format do
   Formats a number as a string, with a unit label. See `Benchee.Conversion.Count`
   and `Benchee.Conversion.Duration` for examples
   """
-  @callback format(number) :: String.t
+  @callback format(number) :: String.t()
 
   # Generic formatting functions
 
@@ -44,6 +44,7 @@ defmodule Benchee.Conversion.Format do
   def format({count, unit = %Unit{}}, module) do
     format(count, label(unit), separator(module))
   end
+
   def format({count, unit_atom}, module) do
     format({count, module.unit_for(unit_atom)}, module)
   end

--- a/lib/benchee/conversion/memory.ex
+++ b/lib/benchee/conversion/memory.ex
@@ -15,35 +15,35 @@ defmodule Benchee.Conversion.Memory do
 
   @units %{
     terabyte: %Unit{
-                name:      :terabyte,
-                magnitude: @bytes_per_terabyte,
-                label:     "TB",
-                long:      "Terabytes"
-              },
+      name: :terabyte,
+      magnitude: @bytes_per_terabyte,
+      label: "TB",
+      long: "Terabytes"
+    },
     gigabyte: %Unit{
-                name:      :gigabyte,
-                magnitude: @bytes_per_gigabyte,
-                label:     "GB",
-                long:      "Gigabytes"
-              },
+      name: :gigabyte,
+      magnitude: @bytes_per_gigabyte,
+      label: "GB",
+      long: "Gigabytes"
+    },
     megabyte: %Unit{
-                name:      :megabyte,
-                magnitude: @bytes_per_megabyte,
-                label:     "MB",
-                long:      "Megabytes"
-              },
+      name: :megabyte,
+      magnitude: @bytes_per_megabyte,
+      label: "MB",
+      long: "Megabytes"
+    },
     kilobyte: %Unit{
-                name:      :kilobyte,
-                magnitude: @bytes_per_kilobyte,
-                label:     "KB",
-                long:      "Kilobytes"
-              },
-    byte:     %Unit{
-                name:      :byte,
-                magnitude: 1,
-                label:     "B",
-                long:      "Bytes"
-              }
+      name: :kilobyte,
+      magnitude: @bytes_per_kilobyte,
+      label: "KB",
+      long: "Kilobytes"
+    },
+    byte: %Unit{
+      name: :byte,
+      magnitude: 1,
+      label: "B",
+      long: "Bytes"
+    }
   }
 
   @doc """
@@ -76,19 +76,23 @@ defmodule Benchee.Conversion.Memory do
     :terabyte
   """
   def scale(memory) when memory >= @bytes_per_terabyte do
-    scale_with_unit memory, :terabyte
+    scale_with_unit(memory, :terabyte)
   end
+
   def scale(memory) when memory >= @bytes_per_gigabyte do
-    scale_with_unit memory, :gigabyte
+    scale_with_unit(memory, :gigabyte)
   end
+
   def scale(memory) when memory >= @bytes_per_megabyte do
-    scale_with_unit memory, :megabyte
+    scale_with_unit(memory, :megabyte)
   end
+
   def scale(memory) when memory >= @bytes_per_kilobyte do
-    scale_with_unit memory, :kilobyte
+    scale_with_unit(memory, :kilobyte)
   end
+
   def scale(memory) do
-    scale_with_unit memory, :byte
+    scale_with_unit(memory, :byte)
   end
 
   # Helper function for returning a tuple of {value, unit}
@@ -110,7 +114,7 @@ defmodule Benchee.Conversion.Memory do
       }
   """
   def unit_for(unit) do
-    Scale.unit_for @units, unit
+    Scale.unit_for(@units, unit)
   end
 
   @doc """
@@ -129,7 +133,7 @@ defmodule Benchee.Conversion.Memory do
 
   """
   def scale(count, unit) do
-    Scale.scale count, unit, __MODULE__
+    Scale.scale(count, unit, __MODULE__)
   end
 
   @doc """
@@ -156,6 +160,7 @@ defmodule Benchee.Conversion.Memory do
       :megabyte
   """
   def best(list, opts \\ [strategy: :best])
+
   def best(list, opts) do
     Scale.best_unit(list, __MODULE__, opts)
   end

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -8,7 +8,7 @@ defmodule Benchee.Conversion.Scale do
 
   alias Benchee.Conversion.Unit
 
-  @type unit :: Unit.t
+  @type unit :: Unit.t()
   @type unit_atom :: atom
   @type any_unit :: unit | unit_atom
   @type scaled_number :: {number, unit}
@@ -60,8 +60,9 @@ defmodule Benchee.Conversion.Scale do
   def scale(value, unit = %Unit{}, _module) do
     scale(value, unit)
   end
+
   def scale(value, unit_atom, module) do
-    scale value, module.unit_for(unit_atom)
+    scale(value, module.unit_for(unit_atom))
   end
 
   @doc """
@@ -82,7 +83,7 @@ defmodule Benchee.Conversion.Scale do
   units. Used by `Benchee.Conversion.Duration` and `Benchee.Conversion.Count`.
   """
   def unit_for(units, unit) do
-    Map.fetch! units, unit
+    Map.fetch!(units, unit)
   end
 
   @doc """
@@ -119,10 +120,10 @@ defmodule Benchee.Conversion.Scale do
   """
   def best_unit(list, module, opts) do
     case Keyword.get(opts, :strategy, :best) do
-      :best     -> best_unit(list, module)
-      :largest  -> largest_unit(list, module)
+      :best -> best_unit(list, module)
+      :largest -> largest_unit(list, module)
       :smallest -> smallest_unit(list, module)
-      :none     -> module.base_unit
+      :none -> module.base_unit
     end
   end
 
@@ -167,6 +168,7 @@ defmodule Benchee.Conversion.Scale do
   defp by_frequency_and_magnitude({unit_a, frequency}, {unit_b, frequency}) do
     magnitude(unit_a) > magnitude(unit_b)
   end
+
   defp by_frequency_and_magnitude({_, frequency_a}, {_, frequency_b}) do
     frequency_a > frequency_b
   end

--- a/lib/benchee/conversion/unit.ex
+++ b/lib/benchee/conversion/unit.ex
@@ -13,9 +13,11 @@ defmodule Benchee.Conversion.Unit do
   """
 
   defstruct [:name, :magnitude, :label, :long]
-  @type t :: %Benchee.Conversion.Unit{name:      atom,
-                                      magnitude: non_neg_integer,
-                                      label:     String.t,
-                                      long:      String.t}
 
+  @type t :: %Benchee.Conversion.Unit{
+          name: atom,
+          magnitude: non_neg_integer,
+          label: String.t(),
+          long: String.t()
+        }
 end

--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -6,20 +6,20 @@ defmodule Benchee.Formatter do
 
   alias Benchee.{Suite, Utility.Parallel}
 
-  @callback output(Suite.t) :: Suite.t
-  @callback format(Suite.t) :: any
-  @callback write(any) :: :ok | {:error, String.t}
+  @callback output(Suite.t()) :: Suite.t()
+  @callback format(Suite.t()) :: any
+  @callback write(any) :: :ok | {:error, String.t()}
 
   @doc """
   Invokes `format/1` and `write/1` as defined by the `Benchee.Formatter`
   behaviour. The output for all formatters are generated in parallel, and then
   the results of that formatting are written in sequence.
   """
-  @spec parallel_output(Suite.t, [module]) :: Suite.t
+  @spec parallel_output(Suite.t(), [module]) :: Suite.t()
   def parallel_output(suite, modules) do
     modules
-    |> Parallel.map(fn(module) -> {module, module.format(suite)} end)
-    |> Enum.each(fn({module, output}) -> module.write(output) end)
+    |> Parallel.map(fn module -> {module, module.format(suite)} end)
+    |> Enum.each(fn {module, output} -> module.write(output) end)
 
     suite
   end

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -9,7 +9,9 @@ defmodule Benchee.Output.BenchmarkPrinter do
   How would you want to discern those anyhow?
   """
   def duplicate_benchmark_warning(name) do
-    IO.puts "You already have a job defined with the name \"#{name}\", you can't add two jobs with the same name!"
+    IO.puts(
+      "You already have a job defined with the name \"#{name}\", you can't add two jobs with the same name!"
+    )
   end
 
   @doc """
@@ -19,34 +21,39 @@ defmodule Benchee.Output.BenchmarkPrinter do
   def configuration_information(%{configuration: %{print: %{configuration: false}}}) do
     nil
   end
+
   def configuration_information(%{scenarios: scenarios, system: sys, configuration: config}) do
     system_information(sys)
     suite_information(scenarios, config)
   end
 
-  defp system_information(%{erlang: erlang_version,
-                            elixir: elixir_version,
-                            os: os,
-                            num_cores: num_cores,
-                            cpu_speed: cpu_speed,
-                            available_memory: available_memory}) do
-    IO.puts "Operating System: #{os}"
-    IO.puts "CPU Information: #{cpu_speed}"
-    IO.puts "Number of Available Cores: #{num_cores}"
-    IO.puts "Available memory: #{available_memory}"
-    IO.puts "Elixir #{elixir_version}"
-    IO.puts "Erlang #{erlang_version}"
+  defp system_information(%{
+         erlang: erlang_version,
+         elixir: elixir_version,
+         os: os,
+         num_cores: num_cores,
+         cpu_speed: cpu_speed,
+         available_memory: available_memory
+       }) do
+    IO.puts("Operating System: #{os}")
+    IO.puts("CPU Information: #{cpu_speed}")
+    IO.puts("Number of Available Cores: #{num_cores}")
+    IO.puts("Available memory: #{available_memory}")
+    IO.puts("Elixir #{elixir_version}")
+    IO.puts("Erlang #{erlang_version}")
   end
 
-  defp suite_information(scenarios, %{parallel: parallel,
-                                 time:     time,
-                                 warmup:   warmup,
-                                 inputs:   inputs}) do
-    job_count      = length(scenarios)
-    exec_time      = warmup + time
-    total_time     = job_count * inputs_count(inputs) * exec_time
+  defp suite_information(scenarios, %{
+         parallel: parallel,
+         time: time,
+         warmup: warmup,
+         inputs: inputs
+       }) do
+    job_count = length(scenarios)
+    exec_time = warmup + time
+    total_time = job_count * inputs_count(inputs) * exec_time
 
-    IO.puts """
+    IO.puts("""
     Benchmark suite executing with the following configuration:
     warmup: #{Duration.format(warmup)}
     time: #{Duration.format(time)}
@@ -54,16 +61,18 @@ defmodule Benchee.Output.BenchmarkPrinter do
     inputs: #{inputs_out(inputs)}
     Estimated total run time: #{Duration.format(total_time)}
 
-    """
+    """)
   end
 
-  defp inputs_count(nil),    do: 1 # no input specified still executes
+  # no input specified still executes
+  defp inputs_count(nil), do: 1
   defp inputs_count(inputs), do: map_size(inputs)
 
   defp inputs_out(nil), do: "none specified"
+
   defp inputs_out(inputs) do
     inputs
-    |> Map.keys
+    |> Map.keys()
     |> Enum.join(", ")
   end
 
@@ -71,19 +80,20 @@ defmodule Benchee.Output.BenchmarkPrinter do
   Prints a notice which job is currently being benchmarked.
   """
   def benchmarking(_, %{print: %{benchmarking: false}}), do: nil
+
   def benchmarking(name, _config) do
-    IO.puts "Benchmarking #{name}..."
+    IO.puts("Benchmarking #{name}...")
   end
 
   @doc """
   Prints a warning about accuracy of benchmarks when the function is super fast.
   """
   def fast_warning do
-    IO.puts """
+    IO.puts("""
     Warning: The function you are trying to benchmark is super fast, making measures more unreliable! See: https://github.com/PragTob/benchee/wiki/Benchee-Warnings#fast-execution-warning
 
     You may disable this warning by passing print: [fast_warning: false] as configuration options.
-    """
+    """)
   end
 
   @doc """
@@ -93,10 +103,10 @@ defmodule Benchee.Output.BenchmarkPrinter do
   def input_information(_, %{print: %{benchmarking: false}}) do
     nil
   end
+
   def input_information(input_name, _config) do
-    if input_name != Benchmark.no_input do
-      IO.puts "\nBenchmarking with input #{input_name}:"
+    if input_name != Benchmark.no_input() do
+      IO.puts("\nBenchmarking with input #{input_name}:")
     end
   end
-
 end

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -6,26 +6,35 @@ defmodule Benchee.Statistics do
 
   alias Benchee.Statistics.Mode
 
-  defstruct [:average, :ips, :std_dev, :std_dev_ratio, :std_dev_ips, :median,
-             :mode, :minimum, :maximum, :sample_size]
+  defstruct [
+    :average,
+    :ips,
+    :std_dev,
+    :std_dev_ratio,
+    :std_dev_ips,
+    :median,
+    :mode,
+    :minimum,
+    :maximum,
+    :sample_size
+  ]
 
   @type t :: %__MODULE__{
-    average: float,
-    ips: float,
-    std_dev: float,
-    std_dev_ratio: float,
-    std_dev_ips: float,
-    median: number,
-    mode: number,
-    minimum: number,
-    maximum: number,
-    sample_size: integer
-  }
+          average: float,
+          ips: float,
+          std_dev: float,
+          std_dev_ratio: float,
+          std_dev_ips: float,
+          median: number,
+          mode: number,
+          minimum: number,
+          maximum: number,
+          sample_size: integer
+        }
 
   @type samples :: [number]
 
-  alias Benchee.{Statistics, Conversion.Duration, Suite, Benchmark.Scenario,
-                 Utility.Parallel}
+  alias Benchee.{Statistics, Conversion.Duration, Suite, Benchmark.Scenario, Utility.Parallel}
   require Integer
 
   @doc """
@@ -44,11 +53,9 @@ defmodule Benchee.Statistics do
   """
   @spec sort([%Scenario{}]) :: [%Scenario{}]
   def sort(scenarios) do
-    Enum.sort_by(scenarios,
-      fn(%Scenario{run_time_statistics: %Statistics{average: average}}) ->
-        average
-      end
-    )
+    Enum.sort_by(scenarios, fn %Scenario{run_time_statistics: %Statistics{average: average}} ->
+      average
+    end)
   end
 
   @doc """
@@ -118,12 +125,13 @@ defmodule Benchee.Statistics do
       }
 
   """
-  @spec statistics(Suite.t) :: Suite.t
+  @spec statistics(Suite.t()) :: Suite.t()
   def statistics(suite = %Suite{scenarios: scenarios}) do
-    new_scenarios = Parallel.map(scenarios, fn(scenario) ->
-      stats = job_statistics(scenario.run_times)
-      %Scenario{scenario | run_time_statistics: stats}
-    end)
+    new_scenarios =
+      Parallel.map(scenarios, fn scenario ->
+        stats = job_statistics(scenario.run_times)
+        %Scenario{scenario | run_time_statistics: stats}
+      end)
 
     %Suite{suite | scenarios: new_scenarios}
   end
@@ -150,31 +158,31 @@ defmodule Benchee.Statistics do
       }
 
   """
-  @spec job_statistics(samples) :: __MODULE__.t
+  @spec job_statistics(samples) :: __MODULE__.t()
   def job_statistics(run_times) do
-    total_time          = Enum.sum(run_times)
-    iterations          = Enum.count(run_times)
-    average             = total_time / iterations
-    ips                 = iterations_per_second(average)
-    deviation           = standard_deviation(run_times, average, iterations)
-    standard_dev_ratio  = deviation / average
-    standard_dev_ips    = ips * standard_dev_ratio
-    median              = compute_median(run_times, iterations)
-    mode                = Mode.mode(run_times)
-    minimum             = Enum.min run_times
-    maximum             = Enum.max run_times
+    total_time = Enum.sum(run_times)
+    iterations = Enum.count(run_times)
+    average = total_time / iterations
+    ips = iterations_per_second(average)
+    deviation = standard_deviation(run_times, average, iterations)
+    standard_dev_ratio = deviation / average
+    standard_dev_ips = ips * standard_dev_ratio
+    median = compute_median(run_times, iterations)
+    mode = Mode.mode(run_times)
+    minimum = Enum.min(run_times)
+    maximum = Enum.max(run_times)
 
     %__MODULE__{
-      average:       average,
-      ips:           ips,
-      std_dev:       deviation,
+      average: average,
+      ips: ips,
+      std_dev: deviation,
       std_dev_ratio: standard_dev_ratio,
-      std_dev_ips:   standard_dev_ips,
-      median:        median,
-      mode:          mode,
-      minimum:       minimum,
-      maximum:       maximum,
-      sample_size:   iterations
+      std_dev_ips: standard_dev_ips,
+      median: median,
+      mode: mode,
+      minimum: minimum,
+      maximum: maximum,
+      sample_size: iterations
     }
   end
 
@@ -183,11 +191,11 @@ defmodule Benchee.Statistics do
   end
 
   defp standard_deviation(samples, average, iterations) do
-    total_variance = Enum.reduce samples, 0,  fn(sample, total) ->
-      total + :math.pow((sample - average), 2)
-    end
+    total_variance =
+      Enum.reduce(samples, 0, fn sample, total -> total + :math.pow(sample - average, 2) end)
+
     variance = total_variance / iterations
-    :math.sqrt variance
+    :math.sqrt(variance)
   end
 
   defp compute_median(run_times, iterations) do
@@ -204,6 +212,6 @@ defmodule Benchee.Statistics do
   end
 
   defp to_float(maybe_integer) do
-    :erlang.float maybe_integer
+    :erlang.float(maybe_integer)
   end
 end

--- a/lib/benchee/statistics/mode.ex
+++ b/lib/benchee/statistics/mode.ex
@@ -17,8 +17,8 @@ defmodule Benchee.Statistics.Mode do
   """
   def mode(samples) do
     samples
-    |> Enum.reduce(%{}, fn(sample, counts) ->
-         Map.update(counts, sample, 1, fn(old_value) -> old_value + 1 end)
+    |> Enum.reduce(%{}, fn sample, counts ->
+         Map.update(counts, sample, 1, fn old_value -> old_value + 1 end)
        end)
     |> max_multiple
     |> decide_mode
@@ -29,13 +29,16 @@ defmodule Benchee.Statistics.Mode do
   end
 
   defp max_multiple([{sample, count} | rest], ref = [{_, max_count} | _]) do
-    new_ref = cond do
-                count < max_count  -> ref
-                count == max_count -> [{sample, count} | ref]
-                true               -> [{sample, count}]
-              end
+    new_ref =
+      cond do
+        count < max_count -> ref
+        count == max_count -> [{sample, count} | ref]
+        true -> [{sample, count}]
+      end
+
     max_multiple(rest, new_ref)
   end
+
   defp max_multiple([], ref) do
     ref
   end
@@ -43,8 +46,8 @@ defmodule Benchee.Statistics.Mode do
   defp decide_mode([{nil, _}]), do: nil
   defp decide_mode([{_, 1} | _rest]), do: nil
   defp decide_mode([{sample, _count}]), do: sample
-  defp decide_mode(multi_modes) do
-    Enum.map multi_modes, fn({sample, _}) -> sample end
-  end
 
+  defp decide_mode(multi_modes) do
+    Enum.map(multi_modes, fn {sample, _} -> sample end)
+  end
 end

--- a/lib/benchee/suite.ex
+++ b/lib/benchee/suite.ex
@@ -16,24 +16,26 @@ defmodule Benchee.Suite do
     scenarios: []
   ]
 
-  @type key :: atom | String.t
+  @type key :: atom | String.t()
   @type optional_map :: map | nil
   @type t :: %__MODULE__{
-    configuration: Benchee.Configuration.t | nil,
-    system: optional_map,
-    scenarios: [] | [Benchee.Benchmark.Scenario.t]
-  }
+          configuration: Benchee.Configuration.t() | nil,
+          system: optional_map,
+          scenarios: [] | [Benchee.Benchmark.Scenario.t()]
+        }
 end
 
 defimpl DeepMerge.Resolver, for: Benchee.Suite do
   def resolve(original, override = %Benchee.Suite{}, resolver) do
-    cleaned_override = override
-                       |> Map.from_struct
-                       |> Enum.reject(fn({_key, value}) -> is_nil(value) end)
-                       |> Map.new
+    cleaned_override =
+      override
+      |> Map.from_struct()
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
 
     Map.merge(original, cleaned_override, resolver)
   end
+
   def resolve(original, override, resolver) when is_map(override) do
     Map.merge(original, override, resolver)
   end

--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -9,14 +9,17 @@ defmodule Benchee.System do
   @doc """
   Adds system information to the suite (currently elixir and erlang versions).
   """
-  @spec system(Suite.t) :: Suite.t
+  @spec system(Suite.t()) :: Suite.t()
   def system(suite = %Suite{}) do
-    system_info = %{elixir: elixir(),
-                    erlang: erlang(),
-                    num_cores: num_cores(),
-                    os: os(),
-                    available_memory: available_memory(),
-                    cpu_speed: cpu_speed()}
+    system_info = %{
+      elixir: elixir(),
+      erlang: erlang(),
+      num_cores: num_cores(),
+      os: os(),
+      available_memory: available_memory(),
+      cpu_speed: cpu_speed()
+    }
+
     %Suite{suite | system: system_info}
   end
 
@@ -30,11 +33,14 @@ defmodule Benchee.System do
   """
   def erlang do
     otp_release = :erlang.system_info(:otp_release)
-    file = Path.join([:code.root_dir, "releases", otp_release , "OTP_VERSION"])
+    file = Path.join([:code.root_dir(), "releases", otp_release, "OTP_VERSION"])
+
     case File.read(file) do
-      {:ok, version}    -> String.trim(version)
-      {:error, reason}  ->
-        IO.puts "Error trying to dermine erlang version #{reason}"
+      {:ok, version} ->
+        String.trim(version)
+
+      {:error, reason} ->
+        IO.puts("Error trying to dermine erlang version #{reason}")
     end
   end
 
@@ -52,6 +58,7 @@ defmodule Benchee.System do
     {_, name} = :os.type()
     os(name)
   end
+
   defp os(:darwin), do: :macOS
   defp os(:nt), do: :Windows
   defp os(_), do: :Linux
@@ -65,9 +72,11 @@ defmodule Benchee.System do
   defp cpu_speed(:Windows) do
     parse_cpu_for(:Windows, system_cmd("WMIC", ["CPU", "GET", "NAME"]))
   end
+
   defp cpu_speed(:macOS) do
     parse_cpu_for(:macOS, system_cmd("sysctl", ["-n", "machdep.cpu.brand_string"]))
   end
+
   defp cpu_speed(:Linux) do
     parse_cpu_for(:Linux, system_cmd("cat", ["/proc/cpuinfo"]))
   end
@@ -75,18 +84,20 @@ defmodule Benchee.System do
   @linux_cpuinfo_regex ~r/model name.*:([\w \(\)\-\@\.]*)/i
 
   def parse_cpu_for(_, "N/A"), do: "N/A"
+
   def parse_cpu_for(:Windows, raw_output) do
     "Name" <> cpu_info = raw_output
     String.trim(cpu_info)
   end
+
   def parse_cpu_for(:macOS, raw_output), do: String.trim(raw_output)
+
   def parse_cpu_for(:Linux, raw_output) do
-    match_info = Regex.run(@linux_cpuinfo_regex,
-                           raw_output,
-                           capture: :all_but_first)
+    match_info = Regex.run(@linux_cpuinfo_regex, raw_output, capture: :all_but_first)
+
     case match_info do
       [cpu_info] -> String.trim(cpu_info)
-      _          -> "Unrecognized processor"
+      _ -> "Unrecognized processor"
     end
   end
 
@@ -102,35 +113,44 @@ defmodule Benchee.System do
       system_cmd("WMIC", ["COMPUTERSYSTEM", "GET", "TOTALPHYSICALMEMORY"])
     )
   end
+
   defp available_memory(:macOS) do
     parse_memory_for(:macOS, system_cmd("sysctl", ["-n", "hw.memsize"]))
   end
+
   defp available_memory(:Linux) do
     parse_memory_for(:Linux, system_cmd("cat", ["/proc/meminfo"]))
   end
 
   defp parse_memory_for(_, "N/A"), do: "N/A"
+
   defp parse_memory_for(:Windows, raw_output) do
     [memory] = Regex.run(~r/\d+/, raw_output)
     {memory, _} = Integer.parse(memory)
     Memory.format(memory)
   end
+
   defp parse_memory_for(:macOS, raw_output) do
     {memory, _} = Integer.parse(raw_output)
     Memory.format(memory)
   end
+
   defp parse_memory_for(:Linux, raw_output) do
     ["MemTotal:" <> memory_info] = Regex.run(~r/MemTotal.*kB/, raw_output)
-    {memory_in_kilobytes, _} = memory_info
-                  |> String.trim()
-                  |> String.trim_trailing(" kB")
-                  |> Integer.parse
+
+    {memory_in_kilobytes, _} =
+      memory_info
+      |> String.trim()
+      |> String.trim_trailing(" kB")
+      |> Integer.parse()
+
     memory_in_bytes = memory_in_kilobytes * 1024
     Memory.format(memory_in_bytes)
   end
 
   def system_cmd(cmd, args, system_func \\ &System.cmd/2) do
     {output, exit_code} = system_func.(cmd, args)
+
     if exit_code > 0 do
       IO.puts("Something went wrong trying to get system information:")
       IO.puts(output)

--- a/lib/benchee/utility/deep_convert.ex
+++ b/lib/benchee/utility/deep_convert.ex
@@ -26,9 +26,9 @@ defmodule Benchee.Utility.DeepConvert do
 
   defp do_to_map(kwlist = [{_key, _value} | _tail]) do
     kwlist
-    |> Enum.map(fn({key, value}) -> {key, do_to_map(value)} end)
-    |> Map.new
+    |> Enum.map(fn {key, value} -> {key, do_to_map(value)} end)
+    |> Map.new()
   end
-  defp do_to_map(no_list), do: no_list
 
+  defp do_to_map(no_list), do: no_list
 end

--- a/lib/benchee/utility/file_creation.ex
+++ b/lib/benchee/utility/file_creation.ex
@@ -32,23 +32,25 @@ defmodule Benchee.Utility.FileCreation do
         fn(file, content) -> IO.write(file, content) end)
   """
   def each(names_to_content, filename, function \\ &default_each/3) do
-    create_directory filename
-    Enum.each names_to_content, fn({input_name, content}) ->
+    create_directory(filename)
+
+    Enum.each(names_to_content, fn {input_name, content} ->
       input_filename = interleave(filename, input_name)
-      File.open input_filename, [:write, :utf8], fn(file) ->
+
+      File.open(input_filename, [:write, :utf8], fn file ->
         function.(file, content, input_filename)
-      end
-    end
+      end)
+    end)
   end
 
   defp default_each(file, content, input_filename) do
-    :ok = IO.write file, content
-    IO.puts "Generated #{input_filename}"
+    :ok = IO.write(file, content)
+    IO.puts("Generated #{input_filename}")
   end
 
   defp create_directory(filename) do
-    directory = Path.dirname filename
-    File.mkdir_p! directory
+    directory = Path.dirname(filename)
+    File.mkdir_p!(directory)
   end
 
   @doc """
@@ -100,13 +102,16 @@ defmodule Benchee.Utility.FileCreation do
       "abc_something_cool_comparison.csv"
   """
   def interleave(filename, names) when is_list(names) do
-    file_names = names
-                 |> Enum.map(&to_filename/1)
-                 |> prepend(Path.rootname(filename))
-                 |> Enum.reject(fn(string) -> String.length(string) < 1 end)
-                 |> Enum.join("_")
+    file_names =
+      names
+      |> Enum.map(&to_filename/1)
+      |> prepend(Path.rootname(filename))
+      |> Enum.reject(fn string -> String.length(string) < 1 end)
+      |> Enum.join("_")
+
     file_names <> Path.extname(filename)
   end
+
   def interleave(filename, name) do
     interleave(filename, [name])
   end
@@ -116,10 +121,13 @@ defmodule Benchee.Utility.FileCreation do
   end
 
   defp to_filename(name_string) do
-    no_input = Benchmark.no_input
+    no_input = Benchmark.no_input()
+
     case name_string do
-      ^no_input -> ""
-      _         ->
+      ^no_input ->
+        ""
+
+      _ ->
         String.downcase(String.replace(name_string, " ", "_"))
     end
   end

--- a/lib/benchee/utility/parallel.ex
+++ b/lib/benchee/utility/parallel.ex
@@ -4,10 +4,10 @@ defmodule Benchee.Utility.Parallel do
   @doc """
   A utility function for mapping over an enumerable collection in parallel.
   """
-  @spec map(Enum.t, fun) :: list
+  @spec map(Enum.t(), fun) :: list
   def map(collection, func) do
     collection
-    |> Enum.map(fn(element) -> Task.async(fn() -> func.(element) end) end)
+    |> Enum.map(fn element -> Task.async(fn -> func.(element) end) end)
     |> Enum.map(&Task.await(&1, :infinity))
   end
 end

--- a/lib/benchee/utility/repeat_n.ex
+++ b/lib/benchee/utility/repeat_n.ex
@@ -7,9 +7,11 @@ defmodule Benchee.Utility.RepeatN do
   def repeat_n(_function, 0) do
     # noop
   end
+
   def repeat_n(function, 1) do
     function.()
   end
+
   def repeat_n(function, count) do
     function.()
     repeat_n(function, count - 1)

--- a/mix.exs
+++ b/mix.exs
@@ -8,21 +8,24 @@ defmodule Benchee.Mixfile do
       app: :benchee,
       version: @version,
       elixir: "~> 1.3",
-      elixirc_paths: elixirc_paths(Mix.env),
+      elixirc_paths: elixirc_paths(Mix.env()),
       consolidate_protocols: true,
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: [source_ref: @version],
       package: package(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test, "coveralls.detail": :test,
-        "coveralls.post": :test, "coveralls.html": :test,
-        "coveralls.travis": :test, "safe_coveralls.travis": :test],
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test,
+        "coveralls.travis": :test,
+        "safe_coveralls.travis": :test
+      ],
       dialyzer: [
-        flags:
-          [:unmatched_returns, :error_handling, :race_conditions, :underspecs]
+        flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs]
       ],
       name: "Benchee",
       source_url: "https://github.com/PragTob/benchee",
@@ -34,7 +37,7 @@ defmodule Benchee.Mixfile do
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support", "mix"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application do
     [applications: [:logger, :deep_merge]]
@@ -42,14 +45,14 @@ defmodule Benchee.Mixfile do
 
   defp deps do
     [
-      {:deep_merge,     "~> 0.1"},
-      {:mix_test_watch, "~> 0.2",   only: :dev},
-      {:credo,          "~> 0.4",   only: :dev},
-      {:ex_doc,         "~> 0.11",  only: :dev},
-      {:earmark,        "~> 1.0", only: :dev},
-      {:excoveralls,    "~> 0.7", only: :test},
-      {:inch_ex,        "~> 0.5",   only: :docs},
-      {:dialyxir,       "~> 0.5",   only: :dev, runtime: false}
+      {:deep_merge, "~> 0.1"},
+      {:mix_test_watch, "~> 0.2", only: :dev},
+      {:credo, "~> 0.4", only: :dev},
+      {:ex_doc, "~> 0.11", only: :dev},
+      {:earmark, "~> 1.0", only: :dev},
+      {:excoveralls, "~> 0.7", only: :test},
+      {:inch_ex, "~> 0.5", only: :docs},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false}
     ]
   end
 
@@ -58,7 +61,7 @@ defmodule Benchee.Mixfile do
       maintainers: ["Tobias Pfeiffer"],
       licenses: ["MIT"],
       links: %{
-        "github"     => "https://github.com/PragTob/benchee",
+        "github" => "https://github.com/PragTob/benchee",
         "Blog posts" => "https://pragtob.wordpress.com/tag/benchee/"
       }
     ]

--- a/mix/tasks.ex
+++ b/mix/tasks.ex
@@ -10,9 +10,9 @@ defmodule Mix.Tasks.SafeCoveralls.Travis do
 
   def run(args) do
     try do
-      Mix.Tasks.Coveralls.do_run(args, [type: "travis"])
+      Mix.Tasks.Coveralls.do_run(args, type: "travis")
     rescue
-      ExCoveralls.ReportUploadError -> IO.puts "Upload to coveralls failed."
+      ExCoveralls.ReportUploadError -> IO.puts("Upload to coveralls failed.")
     end
   end
 end

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -4,18 +4,20 @@ defmodule Benchee.Benchmark.RunnerTest do
   alias Benchee.{Suite, Benchmark, Configuration, Statistics}
   alias Benchee.Test.FakeBenchmarkPrinter, as: TestPrinter
 
-  @config %Configuration{parallel: 1,
-                         time:     40_000,
-                         warmup:   20_000,
-                         inputs:   nil,
-                         print:    %{fast_warning: false, configuration: true}}
+  @config %Configuration{
+    parallel: 1,
+    time: 40000,
+    warmup: 20000,
+    inputs: nil,
+    print: %{fast_warning: false, configuration: true}
+  }
   @system %{
-    elixir:           "1.4.0",
-    erlang:           "19.1",
-    num_cores:        "4",
-    os:               "Super Duper",
+    elixir: "1.4.0",
+    erlang: "19.1",
+    num_cores: "4",
+    os: "Super Duper",
     available_memory: "8 Trillion",
-    cpu_speed:        "light speed"
+    cpu_speed: "light speed"
   }
   @default_suite %Suite{configuration: @config, system: @system}
 
@@ -24,10 +26,11 @@ defmodule Benchee.Benchmark.RunnerTest do
   end
 
   defp run_times_for(suite, job_name, input_name \\ Benchmark.no_input()) do
-    filter_fun = fn(scenario) ->
+    filter_fun = fn scenario ->
       scenario.job_name == job_name && scenario.input_name == input_name
     end
-    map_fun = fn(scenario) -> scenario.run_times end
+
+    map_fun = fn scenario -> scenario.run_times end
 
     suite.scenarios
     |> Enum.filter(filter_fun)
@@ -36,8 +39,9 @@ defmodule Benchee.Benchmark.RunnerTest do
 
   describe ".run_scenarios" do
     test "runs a benchmark suite and enriches it with measurements" do
-      retrying fn ->
-        suite = test_suite(%Suite{configuration: %{time: 60_000, warmup: 10_000}})
+      retrying(fn ->
+        suite = test_suite(%Suite{configuration: %{time: 60000, warmup: 10000}})
+
         new_suite =
           suite
           |> Benchmark.benchmark("Name", fn -> :timer.sleep(10) end)
@@ -48,12 +52,13 @@ defmodule Benchee.Benchmark.RunnerTest do
 
         # should be 6 but gotta give it a bit leeway
         assert length(run_times) >= 5
-      end
+      end)
     end
 
     test "runs a suite with multiple jobs and gathers results" do
-      retrying fn ->
-        suite = test_suite(%Suite{configuration: %{time: 100_000, warmup: 10_000}})
+      retrying(fn ->
+        suite = test_suite(%Suite{configuration: %{time: 100_000, warmup: 10000}})
+
         new_suite =
           suite
           |> Benchmark.benchmark("Name", fn -> :timer.sleep(19) end)
@@ -64,26 +69,29 @@ defmodule Benchee.Benchmark.RunnerTest do
         assert length(run_times_for(new_suite, "Name")) >= 4
         # should be ~11, but gotta give it some leeway
         assert length(run_times_for(new_suite, "Name 2")) >= 8
-      end
+      end)
     end
 
     test "can run multiple benchmarks in parallel" do
-      suite = test_suite(%Suite{configuration: %{parallel: 4, time: 60_000}})
-      new_suite = suite
-                  |> Benchmark.benchmark("", fn -> :timer.sleep 10 end)
-                  |> Benchmark.measure(TestPrinter)
+      suite = test_suite(%Suite{configuration: %{parallel: 4, time: 60000}})
+
+      new_suite =
+        suite
+        |> Benchmark.benchmark("", fn -> :timer.sleep(10) end)
+        |> Benchmark.measure(TestPrinter)
 
       # it does more work when working in parallel than it does alone
       assert length(run_times_for(new_suite, "")) >= 12
     end
 
     test "very fast functions print a warning" do
-      output = ExUnit.CaptureIO.capture_io fn ->
-        %Suite{configuration: %{print: %{fast_warning: true}}}
-        |> test_suite()
-        |> Benchmark.benchmark("", fn -> 1 end)
-        |> Benchmark.measure()
-      end
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          %Suite{configuration: %{print: %{fast_warning: true}}}
+          |> test_suite()
+          |> Benchmark.benchmark("", fn -> 1 end)
+          |> Benchmark.measure()
+        end)
 
       # need to asser on IO here as our message sending trick doesn't work
       # as we spawn new processes to do our benchmarking work therfore the
@@ -92,10 +100,11 @@ defmodule Benchee.Benchmark.RunnerTest do
     end
 
     test "very fast function times are reported correctly" do
-      suite = test_suite()
-              |> Benchmark.benchmark("", fn -> 1 end)
-              |> Benchmark.measure(TestPrinter)
-              |> Benchee.statistics()
+      suite =
+        test_suite()
+        |> Benchmark.benchmark("", fn -> 1 end)
+        |> Benchmark.measure(TestPrinter)
+        |> Benchee.statistics()
 
       [%{run_time_statistics: %{average: average}}] = suite.scenarios
 
@@ -104,42 +113,46 @@ defmodule Benchee.Benchmark.RunnerTest do
     end
 
     test "doesn't take longer than advertised for very fast funs" do
-      retrying fn ->
-        time = 20_000
-        warmup = 10_000
+      retrying(fn ->
+        time = 20000
+        warmup = 10000
         projected = time + warmup
 
-        suite = %Suite{configuration: %{time: time, warmup: warmup}}
-                |> test_suite()
-                |> Benchmark.benchmark("", fn -> :timer.sleep(1) end)
+        suite =
+          %Suite{configuration: %{time: time, warmup: warmup}}
+          |> test_suite()
+          |> Benchmark.benchmark("", fn -> :timer.sleep(1) end)
 
-        {time, _} = :timer.tc fn -> Benchmark.measure(suite, TestPrinter) end
+        {time, _} = :timer.tc(fn -> Benchmark.measure(suite, TestPrinter) end)
 
         # if the system is too busy there are too many false positives
         leeway = projected * 0.4
-        assert_in_delta projected, time, leeway,
+
+        assert_in_delta projected,
+                        time,
+                        leeway,
                         "excution took too long #{time} vs. #{projected} +- #{leeway}"
-      end
+      end)
     end
 
     test "variance does not skyrocket on very fast functions" do
-      retrying fn ->
+      retrying(fn ->
         range = 0..10
-        suite = %Suite{configuration: %{time: 150_000, warmup: 20_000}}
-                |> test_suite
-                |> Benchmark.benchmark("noop", fn -> 1 + 1 end)
-                |> Benchmark.benchmark("map", fn ->
-                     Enum.map(range, fn(i) -> i end)
-                   end)
-                |> Benchmark.measure(TestPrinter)
-                |> Statistics.statistics
 
-        stats = Enum.map(suite.scenarios, fn(scenario) -> scenario.run_time_statistics end)
+        suite =
+          %Suite{configuration: %{time: 150_000, warmup: 20000}}
+          |> test_suite
+          |> Benchmark.benchmark("noop", fn -> 1 + 1 end)
+          |> Benchmark.benchmark("map", fn -> Enum.map(range, fn i -> i end) end)
+          |> Benchmark.measure(TestPrinter)
+          |> Statistics.statistics()
 
-        Enum.each(stats, fn(%Statistics{std_dev_ratio: std_dev_ratio}) ->
+        stats = Enum.map(suite.scenarios, fn scenario -> scenario.run_time_statistics end)
+
+        Enum.each(stats, fn %Statistics{std_dev_ratio: std_dev_ratio} ->
           assert std_dev_ratio <= 2.5
         end)
-      end
+      end)
     end
 
     test "never calls the function if warmup and time are 0" do
@@ -155,7 +168,7 @@ defmodule Benchee.Benchmark.RunnerTest do
 
     test "asks to print what is currently benchmarking" do
       test_suite()
-      |> Benchmark.benchmark("Something", fn -> :timer.sleep 10 end)
+      |> Benchmark.benchmark("Something", fn -> :timer.sleep(10) end)
       |> Benchmark.measure(TestPrinter)
 
       assert_receive {:benchmarking, "Something"}
@@ -168,47 +181,45 @@ defmodule Benchee.Benchmark.RunnerTest do
 
       %Suite{configuration: %{inputs: @inputs}}
       |> test_suite
-      |> Benchmark.benchmark("one", fn(input) -> send ref, {:one, input} end)
-      |> Benchmark.benchmark("two", fn(input) -> send ref, {:two, input} end)
+      |> Benchmark.benchmark("one", fn input -> send(ref, {:one, input}) end)
+      |> Benchmark.benchmark("two", fn input -> send(ref, {:two, input}) end)
       |> Benchmark.measure(TestPrinter)
 
-      Enum.each @inputs, fn({_name, value}) ->
+      Enum.each(@inputs, fn {_name, value} ->
         assert_receive {:one, ^value}
         assert_receive {:two, ^value}
-      end
+      end)
     end
 
     test "notifies which input is being benchmarked now" do
       %Suite{configuration: %{inputs: @inputs}}
       |> test_suite
-      |> Benchmark.benchmark("one", fn(_) -> nil end)
+      |> Benchmark.benchmark("one", fn _ -> nil end)
       |> Benchmark.measure(TestPrinter)
 
-      Enum.each @inputs, fn({name, _value}) ->
-        assert_receive {:input_information, ^name}
-      end
+      Enum.each(@inputs, fn {name, _value} -> assert_receive {:input_information, ^name} end)
     end
 
     test "populates results for all inputs" do
-      retrying fn ->
+      retrying(fn ->
         inputs = %{
-          "Short wait"  => 9,
+          "Short wait" => 9,
           "Longer wait" => 19
         }
-        config = %{time: 100_000,
-                   warmup: 10_000,
-                   inputs: inputs}
+
+        config = %{time: 100_000, warmup: 10000, inputs: inputs}
+
         new_suite =
           %Suite{configuration: config}
           |> test_suite
-          |> Benchmark.benchmark("sleep", fn(input) -> :timer.sleep(input) end)
+          |> Benchmark.benchmark("sleep", fn input -> :timer.sleep(input) end)
           |> Benchmark.measure(TestPrinter)
 
         # should be ~11 but the good old leeway
         assert length(run_times_for(new_suite, "sleep", "Short wait")) >= 8
         # should be 5 but the good old leeway
         assert length(run_times_for(new_suite, "sleep", "Longer wait")) >= 4
-      end
+      end)
     end
 
     test "runs the job exactly once if its time exceeds given time" do
@@ -222,47 +233,52 @@ defmodule Benchee.Benchmark.RunnerTest do
     end
 
     test "stores run times in the right order" do
-      retrying fn ->
-        {:ok, agent} = Agent.start fn -> 10 end
+      retrying(fn ->
+        {:ok, agent} = Agent.start(fn -> 10 end)
+
         increasing_function = fn ->
-          Agent.update agent, fn(state) ->
-            :timer.sleep state
+          Agent.update(agent, fn state ->
+            :timer.sleep(state)
             state + 30
-          end
+          end)
         end
+
         run_times =
-          %Suite{configuration: %{time: 70_000, warmup: 0}}
+          %Suite{configuration: %{time: 70000, warmup: 0}}
           |> test_suite
           |> Benchmark.benchmark("Sleep more", increasing_function)
           |> Benchmark.measure(TestPrinter)
           |> run_times_for("Sleep more")
 
-        assert length(run_times) >= 2 # should be 3 but good old leeway
+        # should be 3 but good old leeway
+        assert length(run_times) >= 2
         # as the function takes more time each time called run times should be
         # as if sorted ascending
         assert run_times == Enum.sort(run_times)
-      end
+      end)
     end
 
     test "global hooks triggers" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 0,
           time: 100,
           before_each: fn -> send(me, :before) end,
-          after_each: fn(_) -> send(me, :after) end
+          after_each: fn _ -> send(me, :after) end
         }
       }
       |> test_suite
-      |> Benchmark.benchmark("job", fn -> :timer.sleep 1 end)
+      |> Benchmark.benchmark("job", fn -> :timer.sleep(1) end)
       |> Benchmark.measure(TestPrinter)
 
-      assert_received_exactly [:before, :after]
+      assert_received_exactly([:before, :after])
     end
 
     test "scenario hooks triggers" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 0,
@@ -271,20 +287,25 @@ defmodule Benchee.Benchmark.RunnerTest do
       }
       |> test_suite
       |> Benchmark.benchmark("job", {
-           fn -> :timer.sleep 1 end,
+           fn -> :timer.sleep(1) end,
            before_each: fn -> send(me, :before) end,
-           after_each: fn(_) -> send(me, :after) end,
+           after_each: fn _ -> send(me, :after) end,
            before_scenario: fn -> send(me, :before_scenario) end,
-           after_scenario: fn -> send(me, :after_scenario) end})
+           after_scenario: fn -> send(me, :after_scenario) end
+         })
       |> Benchmark.measure(TestPrinter)
 
-      assert_received_exactly [
-        :before_scenario, :before, :after, :after_scenario
-      ]
+      assert_received_exactly([
+        :before_scenario,
+        :before,
+        :after,
+        :after_scenario
+      ])
     end
 
     test "hooks trigger during warmup and runtime but scenarios once" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 100,
@@ -293,153 +314,190 @@ defmodule Benchee.Benchmark.RunnerTest do
       }
       |> test_suite
       |> Benchmark.benchmark("job", {
-           fn -> :timer.sleep 1 end,
+           fn -> :timer.sleep(1) end,
            before_each: fn -> send(me, :before) end,
-           after_each: fn(_) -> send(me, :after) end,
+           after_each: fn _ -> send(me, :after) end,
            before_scenario: fn -> send(me, :before_scenario) end,
-           after_scenario: fn -> send(me, :after_scenario) end})
+           after_scenario: fn -> send(me, :after_scenario) end
+         })
       |> Benchmark.measure(TestPrinter)
 
-      assert_received_exactly [
-        :before_scenario, :before, :after, :before, :after, :after_scenario
-      ]
+      assert_received_exactly([
+        :before_scenario,
+        :before,
+        :after,
+        :before,
+        :after,
+        :after_scenario
+      ])
     end
 
     test "hooks trigger for each input" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 0,
           time: 100,
-          before_each: fn -> send me, :global_before end,
-          after_each:  fn(_) -> send me, :global_after end,
-          before_scenario: fn -> send me, :global_before_scenario end,
-          after_scenario:  fn -> send me, :global_after_scenario end,
+          before_each: fn -> send(me, :global_before) end,
+          after_each: fn _ -> send(me, :global_after) end,
+          before_scenario: fn -> send(me, :global_before_scenario) end,
+          after_scenario: fn -> send(me, :global_after_scenario) end,
           inputs: %{"one" => 1, "two" => 2}
         }
       }
       |> test_suite
       |> Benchmark.benchmark("job", {
-           fn(_) -> :timer.sleep 1 end,
+           fn _ -> :timer.sleep(1) end,
            before_each: fn -> send(me, :local_before) end,
-           after_each: fn(_) -> send(me, :local_after) end,
+           after_each: fn _ -> send(me, :local_after) end,
            before_scenario: fn -> send(me, :local_before_scenario) end,
-           after_scenario: fn -> send(me, :local_after_scenario) end})
+           after_scenario: fn -> send(me, :local_after_scenario) end
+         })
       |> Benchmark.measure(TestPrinter)
 
-      assert_received_exactly [
-        :global_before_scenario, :local_before_scenario, :global_before, :local_before, :local_after, :global_after, :local_after_scenario,
+      assert_received_exactly([
+        :global_before_scenario,
+        :local_before_scenario,
+        :global_before,
+        :local_before,
+        :local_after,
+        :global_after,
+        :local_after_scenario,
         :global_after_scenario,
-        :global_before_scenario, :local_before_scenario, :global_before, :local_before, :local_after, :global_after, :local_after_scenario,
-        :global_after_scenario,
-      ]
+        :global_before_scenario,
+        :local_before_scenario,
+        :global_before,
+        :local_before,
+        :local_after,
+        :global_after,
+        :local_after_scenario,
+        :global_after_scenario
+      ])
     end
 
     test "scenario hooks trigger only for that scenario" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 0,
           time: 100,
-          before_each: fn -> send me, :global_before end,
-          after_each:  fn(_) -> send me, :global_after end,
-          after_scenario: fn -> send me, :global_after_scenario end
+          before_each: fn -> send(me, :global_before) end,
+          after_each: fn _ -> send(me, :global_after) end,
+          after_scenario: fn -> send(me, :global_after_scenario) end
         }
       }
       |> test_suite
       |> Benchmark.benchmark("job", {
-           fn -> :timer.sleep 1 end,
-           before_each: fn -> send me, :local_1_before end,
-           before_scenario: fn -> send me, :local_scenario_before end})
-      |> Benchmark.benchmark("job 2", fn -> :timer.sleep 1 end)
+           fn -> :timer.sleep(1) end,
+           before_each: fn -> send(me, :local_1_before) end,
+           before_scenario: fn -> send(me, :local_scenario_before) end
+         })
+      |> Benchmark.benchmark("job 2", fn -> :timer.sleep(1) end)
       |> Benchmark.measure(TestPrinter)
 
-      assert_received_exactly [
-        :global_before, :local_scenario_before, :local_1_before, :global_after,
+      assert_received_exactly([
+        :global_before,
+        :local_scenario_before,
+        :local_1_before,
+        :global_after,
         :global_after_scenario,
-        :global_before, :global_after, :global_after_scenario
-      ]
+        :global_before,
+        :global_after,
+        :global_after_scenario
+      ])
     end
 
     test "different hooks trigger only for that scenario" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 0,
           time: 100,
-          before_each: fn -> send me, :global_before end,
-          after_each:  fn(_) -> send me, :global_after end
+          before_each: fn -> send(me, :global_before) end,
+          after_each: fn _ -> send(me, :global_after) end
         }
       }
       |> test_suite
       |> Benchmark.benchmark("job", {
-           fn -> :timer.sleep 1 end,
-           before_each: fn -> send me, :local_before end,
-           after_each:  fn(_) -> send me, :local_after end,
-           before_scenario: fn -> send me, :local_before_scenario end})
+           fn -> :timer.sleep(1) end,
+           before_each: fn -> send(me, :local_before) end,
+           after_each: fn _ -> send(me, :local_after) end,
+           before_scenario: fn -> send(me, :local_before_scenario) end
+         })
       |> Benchmark.benchmark("job 2", {
-           fn -> :timer.sleep 1 end,
-           before_each: fn -> send me, :local_2_before end,
-           after_each:  fn(_) -> send me, :local_2_after end,
-           after_scenario: fn -> send me, :local_2_after_scenario end})
+           fn -> :timer.sleep(1) end,
+           before_each: fn -> send(me, :local_2_before) end,
+           after_each: fn _ -> send(me, :local_2_after) end,
+           after_scenario: fn -> send(me, :local_2_after_scenario) end
+         })
       |> Benchmark.measure(TestPrinter)
 
-      assert_received_exactly [
-        :local_before_scenario, :global_before, :local_before, :local_after,
+      assert_received_exactly([
+        :local_before_scenario,
+        :global_before,
+        :local_before,
+        :local_after,
         :global_after,
-        :global_before, :local_2_before, :local_2_after, :global_after,
+        :global_before,
+        :local_2_before,
+        :local_2_after,
+        :global_after,
         :local_2_after_scenario
-      ]
+      ])
     end
 
     test "each triggers for every invocation, scenario once" do
       me = self()
+
       suite = %Suite{
-                configuration: %{
-                  warmup: 0,
-                  time: 10_000,
-                  before_each: fn -> send me, :global_before end,
-                  after_each:  fn(_) -> send me, :global_after end,
-                  before_scenario: fn -> send me, :global_before_scenario end,
-                  after_scenario: fn -> send me, :global_after_scenario end,
-                }
-              }
+        configuration: %{
+          warmup: 0,
+          time: 10000,
+          before_each: fn -> send(me, :global_before) end,
+          after_each: fn _ -> send(me, :global_after) end,
+          before_scenario: fn -> send(me, :global_before_scenario) end,
+          after_scenario: fn -> send(me, :global_after_scenario) end
+        }
+      }
+
       result =
         suite
         |> test_suite
         |> Benchmark.benchmark("job", {
-             fn -> :timer.sleep 1 end,
-             before_each: fn -> send me, :local_before end,
-             after_each:  fn(_) -> send me, :local_after end,
+             fn -> :timer.sleep(1) end,
+             before_each: fn -> send(me, :local_before) end,
+             after_each: fn _ -> send(me, :local_after) end,
              before_scenario: fn -> send(me, :local_before_scenario) end,
-             after_scenario: fn -> send(me, :local_after_scenario) end})
+             after_scenario: fn -> send(me, :local_after_scenario) end
+           })
         |> Benchmark.measure(TestPrinter)
 
-      {:messages, messages} = Process.info self(), :messages
+      {:messages, messages} = Process.info(self(), :messages)
 
       global_before_sceneario_count =
-        Enum.count messages, fn(msg) -> msg == :global_before_scenario end
+        Enum.count(messages, fn msg -> msg == :global_before_scenario end)
+
       local_before_sceneario_count =
-        Enum.count messages, fn(msg) -> msg == :local_before_scenario end
+        Enum.count(messages, fn msg -> msg == :local_before_scenario end)
+
       local_after_sceneario_count =
-        Enum.count messages, fn(msg) -> msg == :local_after_scenario end
+        Enum.count(messages, fn msg -> msg == :local_after_scenario end)
+
       global_after_sceneario_count =
-        Enum.count messages, fn(msg) -> msg == :global_after_scenario end
+        Enum.count(messages, fn msg -> msg == :global_after_scenario end)
 
       assert global_before_sceneario_count == 1
-      assert local_before_sceneario_count  == 1
-      assert local_after_sceneario_count   == 1
-      assert global_after_sceneario_count  == 1
+      assert local_before_sceneario_count == 1
+      assert local_after_sceneario_count == 1
+      assert global_after_sceneario_count == 1
 
-      global_before_count =
-        Enum.count messages, fn(message) -> message == :global_before end
-      local_before_count =
-        Enum.count messages, fn(message) -> message == :local_before end
-      local_after_count =
-        Enum.count messages, fn(message) -> message == :local_after end
-      global_after_count =
-        Enum.count messages, fn(message) -> message == :global_after end
-
+      global_before_count = Enum.count(messages, fn message -> message == :global_before end)
+      local_before_count = Enum.count(messages, fn message -> message == :local_before end)
+      local_after_count = Enum.count(messages, fn message -> message == :local_after end)
+      global_after_count = Enum.count(messages, fn message -> message == :global_after end)
 
       assert local_before_count == global_before_count
       assert local_after_count == global_after_count
@@ -456,32 +514,31 @@ defmodule Benchee.Benchmark.RunnerTest do
 
     test "hooks also trigger for very fast invocations" do
       me = self()
+
       suite = %Suite{
-                configuration: %{
-                  warmup: 0,
-                  time: 1_000,
-                  before_each: fn -> send me, :global_before end,
-                  after_each:  fn(_) -> send me, :global_after end
-                }
-              }
+        configuration: %{
+          warmup: 0,
+          time: 1000,
+          before_each: fn -> send(me, :global_before) end,
+          after_each: fn _ -> send(me, :global_after) end
+        }
+      }
+
       result =
         suite
         |> test_suite
-        |> Benchmark.benchmark("job", {fn -> 0 end,
-                               before_each: fn -> send me, :local_before end,
-                               after_each:  fn(_) -> send me, :local_after end})
+        |> Benchmark.benchmark("job", {
+             fn -> 0 end,
+             before_each: fn -> send(me, :local_before) end,
+             after_each: fn _ -> send(me, :local_after) end
+           })
         |> Benchmark.measure(TestPrinter)
 
-      {:messages, messages} = Process.info self(), :messages
-      global_before_count =
-        Enum.count messages, fn(message) -> message == :global_before end
-      local_before_count =
-        Enum.count messages, fn(message) -> message == :local_before end
-      local_after_count =
-        Enum.count messages, fn(message) -> message == :local_after end
-      global_after_count =
-        Enum.count messages, fn(message) -> message == :global_after end
-
+      {:messages, messages} = Process.info(self(), :messages)
+      global_before_count = Enum.count(messages, fn message -> message == :global_before end)
+      local_before_count = Enum.count(messages, fn message -> message == :local_before end)
+      local_after_count = Enum.count(messages, fn message -> message == :local_after end)
+      global_after_count = Enum.count(messages, fn message -> message == :global_after end)
 
       assert local_before_count == global_before_count
       assert local_after_count == global_after_count
@@ -501,42 +558,52 @@ defmodule Benchee.Benchmark.RunnerTest do
 
     test "after_each hooks have access to the return value of the invocation" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 100,
           time: 100,
-          after_each: fn(out) -> send(me, {:global, out}) end
+          after_each: fn out -> send(me, {:global, out}) end
         }
       }
       |> test_suite
-      |> Benchmark.benchmark("job", {fn ->
-           # still keep to make sure we only get one iteration and not too fast
-           :timer.sleep 1
-           :value
-         end, after_each: fn(out) -> send(me, {:local, out}) end})
+      |> Benchmark.benchmark("job", {
+           fn ->
+             # still keep to make sure we only get one iteration and not too fast
+             :timer.sleep(1)
+             :value
+           end,
+           after_each: fn out -> send(me, {:local, out}) end
+         })
       |> Benchmark.measure(TestPrinter)
 
-      assert_received_exactly [
-        {:global, :value}, {:local, :value},
-        {:global, :value}, {:local, :value}
-      ]
+      assert_received_exactly([
+        {:global, :value},
+        {:local, :value},
+        {:global, :value},
+        {:local, :value}
+      ])
     end
 
     test "after_each hooks with super fast functions" do
       me = self()
+
       %Suite{
         configuration: %{
           warmup: 100,
           time: 100,
-          after_each: fn(out) -> send(me, {:global, out}) end
+          after_each: fn out -> send(me, {:global, out}) end
         }
       }
       |> test_suite
-      |> Benchmark.benchmark("job", {fn ->
-           # still keep to make sure we only get one iteration and not too fast
-           :timer.sleep 1
-           :value
-         end, after_each: fn(out) -> send(me, {:local, out}) end})
+      |> Benchmark.benchmark("job", {
+           fn ->
+             # still keep to make sure we only get one iteration and not too fast
+             :timer.sleep(1)
+             :value
+           end,
+           after_each: fn out -> send(me, {:local, out}) end
+         })
       |> Benchmark.measure(TestPrinter)
 
       assert_received {:global, :value}
@@ -544,6 +611,5 @@ defmodule Benchee.Benchmark.RunnerTest do
       assert_received {:global, :value}
       assert_received {:local, :value}
     end
-
   end
 end

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -4,16 +4,17 @@ defmodule Benchee.BenchmarkTest do
   alias Benchee.Configuration
   alias Benchee.Benchmark.{Scenario, ScenarioContext}
   alias Benchee.Test.FakeBenchmarkPrinter, as: TestPrinter
-  alias Benchee.Test.FakeBenchmarkRunner,  as: TestRunner
+  alias Benchee.Test.FakeBenchmarkRunner, as: TestRunner
   alias Benchee.Suite
 
   describe ".benchmark" do
     test "can add jobs with atom keys but converts them to string" do
-      suite = %Suite{}
-              |> Benchmark.benchmark("one job", fn -> 1 end)
-              |> Benchmark.benchmark(:something, fn -> 2 end)
+      suite =
+        %Suite{}
+        |> Benchmark.benchmark("one job", fn -> 1 end)
+        |> Benchmark.benchmark(:something, fn -> 2 end)
 
-      job_names = Enum.map(suite.scenarios, fn(scenario) -> scenario.job_name end)
+      job_names = Enum.map(suite.scenarios, fn scenario -> scenario.job_name end)
       assert job_names == ["one job", "something"]
     end
 
@@ -33,9 +34,13 @@ defmodule Benchee.BenchmarkTest do
       function = fn -> 1 end
       config = %Configuration{inputs: nil}
       suite = Benchmark.benchmark(%Suite{configuration: config}, job_name, function)
-      expected_scenario =
-        %Scenario{job_name: job_name, function: function,
-                  input: Benchmark.no_input(), input_name: Benchmark.no_input()}
+
+      expected_scenario = %Scenario{
+        job_name: job_name,
+        function: function,
+        input: Benchmark.no_input(),
+        input_name: Benchmark.no_input()
+      }
 
       assert suite.scenarios == [expected_scenario]
     end
@@ -45,8 +50,8 @@ defmodule Benchee.BenchmarkTest do
       function = fn -> 1 end
       config = %Configuration{inputs: %{"large" => 100_000, "small" => 10}}
       suite = Benchmark.benchmark(%Suite{configuration: config}, job_name, function)
-      input_names = Enum.map(suite.scenarios, fn(scenario) -> scenario.input_name end)
-      inputs = Enum.map(suite.scenarios, fn(scenario) -> scenario.input end)
+      input_names = Enum.map(suite.scenarios, fn scenario -> scenario.input_name end)
+      inputs = Enum.map(suite.scenarios, fn scenario -> scenario.input end)
 
       assert length(suite.scenarios) == 2
       assert input_names == ["large", "small"]
@@ -54,20 +59,25 @@ defmodule Benchee.BenchmarkTest do
     end
 
     test "can deal with the options tuple" do
-      function       = fn -> 1 end
-      before         = fn -> 2 end
+      function = fn -> 1 end
+      before = fn -> 2 end
       after_scenario = fn -> 3 end
+
       suite =
         %Suite{}
         |> Benchmark.benchmark("job", {
-          function, before_each: before, after_scenario: after_scenario})
+             function,
+             before_each: before, after_scenario: after_scenario
+           })
 
       [scenario] = suite.scenarios
+
       assert %{
-        job_name: "job",
-        function: ^function,
-        before_each: ^before,
-        after_scenario: ^after_scenario } = scenario
+               job_name: "job",
+               function: ^function,
+               before_each: ^before,
+               after_scenario: ^after_scenario
+             } = scenario
     end
   end
 
@@ -90,16 +100,17 @@ defmodule Benchee.BenchmarkTest do
     end
 
     test "returns a suite with scenarios returned from the runner" do
-      scenarios = [%Scenario{job_name: "one", function: fn() -> 1 end}]
+      scenarios = [%Scenario{job_name: "one", function: fn -> 1 end}]
       suite = %Suite{scenarios: scenarios}
 
-      run_times = suite
-                  |> Benchmark.measure(TestPrinter, TestRunner)
-                  |> (fn(suite) -> suite.scenarios end).()
-                  |> Enum.map(fn(scenario) -> scenario.run_times end)
+      run_times =
+        suite
+        |> Benchmark.measure(TestPrinter, TestRunner)
+        |> (fn suite -> suite.scenarios end).()
+        |> Enum.map(fn scenario -> scenario.run_times end)
 
       assert length(run_times) == 1
-      refute Enum.any?(run_times, fn(run_time) -> Enum.empty?(run_time) end)
+      refute Enum.any?(run_times, fn run_time -> Enum.empty?(run_time) end)
     end
   end
 end

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -1,6 +1,6 @@
 defmodule Benchee.ConfigurationTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Configuration
+  doctest(Benchee.Configuration)
 
   alias Benchee.{Configuration, Suite}
 
@@ -11,21 +11,19 @@ defmodule Benchee.ConfigurationTest do
 
   describe ".init/1" do
     test "it crashes for values that are going to be ignored" do
-      assert_raise KeyError, fn ->
-        init runntime: 2
-      end
+      assert_raise KeyError, fn -> init(runntime: 2) end
     end
 
     test "it converts input keys to strings" do
-      suite = init inputs: %{"map" => %{}, list: []}
+      suite = init(inputs: %{"map" => %{}, list: []})
 
       assert %Suite{
-        configuration: %{inputs: %{"list" => [], "map" => %{}}}
-      } = suite
+               configuration: %{inputs: %{"list" => [], "map" => %{}}}
+             } = suite
     end
 
     test "it loses duplicated inputs keys after normalization" do
-      suite = init inputs: %{"map" => %{}, map: %{}}
+      suite = init(inputs: %{"map" => %{}, map: %{}})
 
       assert %Suite{configuration: %{inputs: inputs}} = suite
       assert %{"map" => %{}} == inputs
@@ -46,8 +44,8 @@ defmodule Benchee.ConfigurationTest do
         formatter_options: %{
           custom: %{option: true},
           console: %{
-            comparison:    true,
-            unit_scaling:  :best
+            comparison: true,
+            unit_scaling: :best
           }
         }
       }
@@ -60,7 +58,7 @@ defmodule Benchee.ConfigurationTest do
       result = deep_merge(@default_config, other_config)
       expected = %Configuration{formatter_options: %{some: %{value: true}}}
 
-      assert  ^expected = result
+      assert ^expected = result
     end
   end
 end

--- a/test/benchee/conversion/count_test.exs
+++ b/test/benchee/conversion/count_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Conversion.CountTest do
   use ExUnit.Case, async: true
   import Benchee.Conversion.Count
-  doctest Benchee.Conversion.Count
+  doctest(Benchee.Conversion.Count)
 
   describe ".scale" do
     test "123_456_789_012 scales to :billion" do
@@ -33,11 +33,11 @@ defmodule Benchee.Conversion.CountTest do
     end
 
     test "12_345.67 scales to :thousand" do
-      assert scale(12_345.67) == {12.34567, unit_for(:thousand)}
+      assert scale(12345.67) == {12.34567, unit_for(:thousand)}
     end
 
     test "1_234.567 scales to :thousand" do
-      assert scale(1_234.567) == {1.234567, unit_for(:thousand)}
+      assert scale(1234.567) == {1.234567, unit_for(:thousand)}
     end
 
     test "123.4567 scales to :one" do
@@ -63,7 +63,7 @@ defmodule Benchee.Conversion.CountTest do
     end
 
     test "1_000.1234" do
-      assert format(1_000.1234) == "1.00 K"
+      assert format(1000.1234) == "1.00 K"
     end
 
     test "123.4" do
@@ -76,7 +76,7 @@ defmodule Benchee.Conversion.CountTest do
   end
 
   describe ".best" do
-    @list_with_mostly_ones [1, 100, 1_000]
+    @list_with_mostly_ones [1, 100, 1000]
 
     test "when list is mostly ones" do
       assert best(@list_with_mostly_ones) == unit_for(:one)
@@ -90,21 +90,31 @@ defmodule Benchee.Conversion.CountTest do
       assert best(@list_with_mostly_ones, strategy: :largest) == unit_for(:thousand)
     end
 
-    @list_with_thousands_and_millions_tied_for_most [0.0001, 1, 1_000, 100_000, 1_000_000, 10_000_000, 1_000_000_000]
+    @list_with_thousands_and_millions_tied_for_most [
+      0.0001,
+      1,
+      1000,
+      100_000,
+      1_000_000,
+      10_000_000,
+      1_000_000_000
+    ]
 
     test "when list has thousands and millions tied for most, billions highest" do
       assert best(@list_with_thousands_and_millions_tied_for_most) == unit_for(:million)
     end
 
     test "when list has thousands and millions tied for most, billions highest, strategy: :smallest" do
-      assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :smallest) == unit_for(:one)
+      assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :smallest) ==
+               unit_for(:one)
     end
 
     test "when list has thousands and millions tied for most, billions highest, strategy: :largest" do
-      assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :largest) == unit_for(:billion)
+      assert best(@list_with_thousands_and_millions_tied_for_most, strategy: :largest) ==
+               unit_for(:billion)
     end
 
-    @list_with_mostly_thousands [1_000, 2_000, 30_000, 999]
+    @list_with_mostly_thousands [1000, 2000, 30000, 999]
 
     test "when list is mostly thousands" do
       assert best(@list_with_mostly_thousands) == unit_for(:thousand)

--- a/test/benchee/conversion/deviation_percent_test.exs
+++ b/test/benchee/conversion/deviation_percent_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Conversion.DeviationPercentTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Conversion.DeviationPercent
+  doctest(Benchee.Conversion.DeviationPercent)
 end

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Conversion.DurationTest do
   use ExUnit.Case, async: true
   import Benchee.Conversion.Duration
-  doctest Benchee.Conversion.Duration
+  doctest(Benchee.Conversion.Duration)
 
   describe ".format" do
     test ".format(98.7654321)" do
@@ -13,11 +13,11 @@ defmodule Benchee.Conversion.DurationTest do
     end
 
     test ".format(9_876.54321)" do
-      assert format(9_876.54321) == "9.88 ms"
+      assert format(9876.54321) == "9.88 ms"
     end
 
     test ".format(98_765.4321)" do
-      assert format(98_765.4321) == "98.77 ms"
+      assert format(98765.4321) == "98.77 ms"
     end
 
     test ".format(987_654.321)" do
@@ -49,7 +49,7 @@ defmodule Benchee.Conversion.DurationTest do
     end
   end
 
-  @list_with_mostly_milliseconds [1, 200, 3_000, 4_000, 500_000, 6_000_000, 77_000_000_000]
+  @list_with_mostly_milliseconds [1, 200, 3000, 4000, 500_000, 6_000_000, 77_000_000_000]
 
   describe ".best" do
     test "when list is mostly milliseconds" do

--- a/test/benchee/conversion/memory_test.exs
+++ b/test/benchee/conversion/memory_test.exs
@@ -1,15 +1,15 @@
 defmodule Benchee.Conversion.MemoryTest do
   use ExUnit.Case, async: true
   import Benchee.Conversion.Memory
-  doctest Benchee.Conversion.Memory
+  doctest(Benchee.Conversion.Memory)
 
   describe ".format" do
     test ".format(1_023)" do
-      assert format(1_023) == "1023 B"
+      assert format(1023) == "1023 B"
     end
 
     test ".format(1025)" do
-      assert format(1_025) == "1.00 KB"
+      assert format(1025) == "1.00 KB"
     end
 
     test ".format(876_543_219.8765)" do
@@ -33,7 +33,15 @@ defmodule Benchee.Conversion.MemoryTest do
     end
   end
 
-  @list_with_mostly_megabytes [1, 200, 3_000_000, 4_000_000, 50_000_000, 50_000_000, 77_000_000_000]
+  @list_with_mostly_megabytes [
+    1,
+    200,
+    3_000_000,
+    4_000_000,
+    50_000_000,
+    50_000_000,
+    77_000_000_000
+  ]
 
   describe ".best" do
     test "when list is mostly megabytes" do

--- a/test/benchee/conversion/scale_test.exs
+++ b/test/benchee/conversion/scale_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Conversion.ScaleTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Conversion.Scale
+  doctest(Benchee.Conversion.Scale)
 end

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -2,7 +2,7 @@ defmodule Benchee.Formatters.ConsoleTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureIO
   import Benchee.Benchmark, only: [no_input: 0]
-  doctest Benchee.Formatters.Console
+  doctest(Benchee.Formatters.Console)
 
   alias Benchee.Formatters.Console
   alias Benchee.{Suite, Statistics, Benchmark.Scenario}
@@ -12,21 +12,32 @@ defmodule Benchee.Formatters.ConsoleTest do
   describe ".output" do
     test "formats and prints the results right to the console" do
       scenarios = [
-        %Scenario{job_name: "Second", input_name: no_input(), input: no_input(),
+        %Scenario{
+          job_name: "Second",
+          input_name: no_input(),
+          input: no_input(),
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
           }
         },
-        %Scenario{job_name: "First", input_name: no_input(), input: no_input(),
-           run_time_statistics: %Statistics{
-            average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
-           }
+        %Scenario{
+          job_name: "First",
+          input_name: no_input(),
+          input: no_input(),
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0
+          }
         }
       ]
 
-      output = capture_io fn ->
-        Console.output %Suite{scenarios: scenarios, configuration: @config}
-      end
+      output =
+        capture_io(fn -> Console.output(%Suite{scenarios: scenarios, configuration: @config}) end)
 
       assert output =~ ~r/First/
       assert output =~ ~r/Second/
@@ -40,151 +51,243 @@ defmodule Benchee.Formatters.ConsoleTest do
   describe ".format_scenarios" do
     test "sorts the the given stats fastest to slowest" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
-        }},
-        %Scenario{job_name: "Third", run_time_statistics: %Statistics{
-          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
-        }},
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
+          }
+        },
+        %Scenario{
+          job_name: "Third",
+          run_time_statistics: %Statistics{
+            average: 400.0,
+            ips: 2500.0,
+            std_dev_ratio: 0.1,
+            median: 375.0
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0
+          }
+        }
       ]
 
       [_header, result_1, result_2, result_3 | _dont_care] =
         Console.format_scenarios(scenarios, @console_config)
 
-      assert Regex.match?(~r/First/,  result_1)
+      assert Regex.match?(~r/First/, result_1)
       assert Regex.match?(~r/Second/, result_2)
-      assert Regex.match?(~r/Third/,  result_3)
+      assert Regex.match?(~r/Third/, result_3)
     end
 
     test "adjusts the label width to longest name" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
-        }}
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 400.0,
+            ips: 2500.0,
+            std_dev_ratio: 0.1,
+            median: 375.0
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
+          }
+        }
       ]
 
-      expected_width = String.length "Second"
+      expected_width = String.length("Second")
+
       [header, result_1, result_2 | _dont_care] =
         Console.format_scenarios(scenarios, @console_config)
 
-      assert_column_width "Name", header, expected_width
-      assert_column_width "First", result_1, expected_width
-      assert_column_width "Second", result_2, expected_width
+      assert_column_width("Name", header, expected_width)
+      assert_column_width("First", result_1, expected_width)
+      assert_column_width("Second", result_2, expected_width)
 
       third_length = 40
       third_name = String.duplicate("a", third_length)
+
       long_scenario = %Scenario{
-        job_name: third_name, run_time_statistics: %Statistics{
-          average: 400.1, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0
-      }}
+        job_name: third_name,
+        run_time_statistics: %Statistics{
+          average: 400.1,
+          ips: 2500.0,
+          std_dev_ratio: 0.1,
+          median: 375.0
+        }
+      }
+
       longer_scenarios = scenarios ++ [long_scenario]
 
       # Include extra long name, expect width of 40 characters
       [header, result_1, result_2, result_3 | _dont_care] =
         Console.format_scenarios(longer_scenarios, @console_config)
 
-      assert_column_width "Name", header, third_length
-      assert_column_width "First", result_1, third_length
-      assert_column_width "Second", result_2, third_length
-      assert_column_width third_name, result_3, third_length
+      assert_column_width("Name", header, third_length)
+      assert_column_width("First", result_1, third_length)
+      assert_column_width("Second", result_2, third_length)
+      assert_column_width(third_name, result_3, third_length)
     end
 
     test "creates comparisons" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
-        }}
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0
+          }
+        }
       ]
 
       [_, _, _, comp_header, reference, slower] =
         Console.format_scenarios(scenarios, @console_config)
 
-      assert Regex.match? ~r/Comparison/, comp_header
-      assert Regex.match? ~r/^First\s+10 K$/m, reference
-      assert Regex.match? ~r/^Second\s+5 K\s+- 2.00x slower/, slower
+      assert Regex.match?(~r/Comparison/, comp_header)
+      assert Regex.match?(~r/^First\s+10 K$/m, reference)
+      assert Regex.match?(~r/^Second\s+5 K\s+- 2.00x slower/, slower)
     end
 
     test "can omit the comparisons" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
-        }}
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0
+          }
+        }
       ]
 
-      output =  Enum.join Console.format_scenarios(
-                  scenarios,
-                  %{
-                    comparison:   false,
-                    unit_scaling: :best
-                  })
+      output =
+        Enum.join(
+          Console.format_scenarios(scenarios, %{
+            comparison: false,
+            unit_scaling: :best
+          })
+        )
 
-      refute Regex.match? ~r/Comparison/i, output
-      refute Regex.match? ~r/^First\s+10 K$/m, output
-      refute Regex.match? ~r/^Second\s+5 K\s+- 2.00x slower/, output
+      refute Regex.match?(~r/Comparison/i, output)
+      refute Regex.match?(~r/^First\s+10 K$/m, output)
+      refute Regex.match?(~r/^Second\s+5 K\s+- 2.00x slower/, output)
     end
 
     test "adjusts the label width to longest name for comparisons" do
       second_name = String.duplicate("a", 40)
+
       scenarios = [
-        %Scenario{job_name: second_name, run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
-        }}
+        %Scenario{
+          job_name: second_name,
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0
+          }
+        }
       ]
 
       expected_width = String.length(second_name)
+
       [_, _, _, _comp_header, reference, slower] =
         Console.format_scenarios(scenarios, @console_config)
 
-      assert_column_width "First", reference, expected_width
-      assert_column_width second_name, slower, expected_width
+      assert_column_width("First", reference, expected_width)
+      assert_column_width(second_name, slower, expected_width)
     end
 
     test "doesn't create comparisons with only one benchmark run" do
       scenarios = [
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
-        }}
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0
+          }
+        }
       ]
 
       assert [header, result] = Console.format_scenarios(scenarios, @console_config)
-      refute Regex.match? ~r/(Comparison|x slower)/, Enum.join([header, result])
+      refute Regex.match?(~r/(Comparison|x slower)/, Enum.join([header, result]))
     end
 
     test "formats small averages and medians more precisely" do
       scenarios = [
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 0.15, ips: 10_000.0, std_dev_ratio: 0.1, median: 0.0125
-        }}
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 0.15,
+            ips: 10000.0,
+            std_dev_ratio: 0.1,
+            median: 0.0125
+          }
+        }
       ]
 
       assert [_, result] = Console.format_scenarios(scenarios, @console_config)
-      assert Regex.match? ~r/0.150\s?μs/, result
-      assert Regex.match? ~r/0.0125\s?μs/, result
+      assert Regex.match?(~r/0.150\s?μs/, result)
+      assert Regex.match?(~r/0.0125\s?μs/, result)
     end
 
     test "doesn't output weird 'e' formats" do
       scenarios = [
-        %Scenario{job_name: "Job", run_time_statistics: %Statistics{
-          average: 11000.0,
-          ips: 12000.0,
-          std_dev_ratio: 13000.0,
-          median: 140000.0
-        }}
+        %Scenario{
+          job_name: "Job",
+          run_time_statistics: %Statistics{
+            average: 11000.0,
+            ips: 12000.0,
+            std_dev_ratio: 13000.0,
+            median: 140_000.0
+          }
+        }
       ]
 
       assert [_, result] = Console.format_scenarios(scenarios, @console_config)
@@ -201,20 +304,31 @@ defmodule Benchee.Formatters.ConsoleTest do
     @header_regex ~r/Name.+ips.+average.+deviation.+median.*/
     test "with multiple inputs and just one job" do
       scenarios = [
-        %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "My Arg",
+          input: "My Arg",
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
           }
         },
-        %Scenario{job_name: "Job", input_name: "Other Arg", input: "Other Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "Other Arg",
+          input: "Other Arg",
           run_time_statistics: %Statistics{
-            average: 400.0, ips: 2_500.0, std_dev_ratio: 0.15, median: 395.0
+            average: 400.0,
+            ips: 2500.0,
+            std_dev_ratio: 0.15,
+            median: 395.0
           }
         }
       ]
 
-      [my_arg, other_arg] =
-        Console.format(%Suite{scenarios: scenarios, configuration: @config})
+      [my_arg, other_arg] = Console.format(%Suite{scenarios: scenarios, configuration: @config})
 
       [input_header, header, result] = my_arg
       assert input_header =~ "My Arg"
@@ -229,30 +343,53 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     test "with multiple inputs and two jobs" do
       scenarios = [
-        %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "My Arg",
+          input: "My Arg",
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+            average: 200.0,
+            ips: 5000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5
           }
         },
-        %Scenario{job_name: "Other Job", input_name: "My Arg", input: "My Arg",
+        %Scenario{
+          job_name: "Other Job",
+          input_name: "My Arg",
+          input: "My Arg",
           run_time_statistics: %Statistics{
-            average: 100.0, ips: 10_000.0, std_dev_ratio: 0.3, median: 98.0
+            average: 100.0,
+            ips: 10000.0,
+            std_dev_ratio: 0.3,
+            median: 98.0
           }
         },
-        %Scenario{job_name: "Job", input_name: "Other Arg", input: "Other Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "Other Arg",
+          input: "Other Arg",
           run_time_statistics: %Statistics{
-            average: 400.0, ips: 2_500.0, std_dev_ratio: 0.15, median: 395.0
+            average: 400.0,
+            ips: 2500.0,
+            std_dev_ratio: 0.15,
+            median: 395.0
           }
         },
-        %Scenario{job_name: "Other Job", input_name: "Other Arg", input: "Other Arg",
+        %Scenario{
+          job_name: "Other Job",
+          input_name: "Other Arg",
+          input: "Other Arg",
           run_time_statistics: %Statistics{
-            average: 250.0, ips: 4_000.0, std_dev_ratio: 0.31, median: 225.5
+            average: 250.0,
+            ips: 4000.0,
+            std_dev_ratio: 0.31,
+            median: 225.5
           }
         }
       ]
 
-      [my_arg, other_arg] =
-        Console.format(%Suite{scenarios: scenarios, configuration: @config})
+      [my_arg, other_arg] = Console.format(%Suite{scenarios: scenarios, configuration: @config})
 
       [input_header, _header, other_job, job, _comp, ref, slower] = my_arg
       assert input_header =~ "My Arg"
@@ -273,16 +410,16 @@ defmodule Benchee.Formatters.ConsoleTest do
   defp assert_column_width(name, string, expected_width) do
     # add 13 characters for the ips column, and an extra space between the columns
     expected_width = expected_width + 14
-    n = Regex.escape name
-    regex = Regex.compile! "(#{n} +([0-9\.]+( [[:alpha:]]+)?|ips))( |$)"
-    assert Regex.match? regex, string
+    n = Regex.escape(name)
+    regex = Regex.compile!("(#{n} +([0-9\.]+( [[:alpha:]]+)?|ips))( |$)")
+    assert Regex.match?(regex, string)
     [column | _] = Regex.run(regex, string, capture: :all_but_first)
     column_width = String.length(column)
 
     assert expected_width == column_width, """
-Expected column width of #{expected_width}, got #{column_width}
-line:   #{inspect String.trim(string)}
-column: #{inspect column}
-"""
+    Expected column width of #{expected_width}, got #{column_width}
+    line:   #{inspect(String.trim(string))}
+    column: #{inspect(column)}
+    """
   end
 end

--- a/test/benchee/output/benchmark_printer_test.exs
+++ b/test/benchee/output/benchmark_printer_test.exs
@@ -3,17 +3,18 @@ defmodule Benchee.Output.BenchmarkPrintertest do
   import ExUnit.CaptureIO
   import Benchee.Output.BenchmarkPrinter
   alias Benchee.Benchmark.Scenario
-  @system_info %{elixir: "1.4",
-                 erlang: "19.2",
-                 os: :macOS,
-                 num_cores: 4,
-                 cpu_speed: "Intel(R) Core(TM) i5-4260U CPU @ 1.40GHz",
-                 available_memory: 8568392814}
+
+  @system_info %{
+    elixir: "1.4",
+    erlang: "19.2",
+    os: :macOS,
+    num_cores: 4,
+    cpu_speed: "Intel(R) Core(TM) i5-4260U CPU @ 1.40GHz",
+    available_memory: 8_568_392_814
+  }
 
   test ".duplicate_benchmark_warning" do
-    output = capture_io fn ->
-      duplicate_benchmark_warning("Something")
-    end
+    output = capture_io(fn -> duplicate_benchmark_warning("Something") end)
 
     assert output =~ "same name"
     assert output =~ "Something"
@@ -21,14 +22,15 @@ defmodule Benchee.Output.BenchmarkPrintertest do
 
   describe ".configuration_information" do
     test "sys information" do
-      output = capture_io fn ->
-        %{
-          configuration: %{parallel: 2, time: 10_000, warmup: 0, inputs: nil},
-          scenarios: [%Scenario{job_name: "one"}, %Scenario{job_name: "two"}],
-          system: @system_info
-        }
-        |> configuration_information
-      end
+      output =
+        capture_io(fn ->
+          %{
+            configuration: %{parallel: 2, time: 10000, warmup: 0, inputs: nil},
+            scenarios: [%Scenario{job_name: "one"}, %Scenario{job_name: "two"}],
+            system: @system_info
+          }
+          |> configuration_information
+        end)
 
       assert output =~ "Erlang 19.2"
       assert output =~ "Elixir 1.4"
@@ -44,19 +46,20 @@ defmodule Benchee.Output.BenchmarkPrintertest do
     end
 
     test "it scales times appropriately" do
-      output = capture_io fn ->
-        %{
-          configuration: %Benchee.Configuration{
-            parallel: 1,
-            time: 60_000_000,
-            warmup: 10_000_000,
-            inputs: nil
-          },
-          scenarios: [%Scenario{job_name: "one"}, %Scenario{job_name: "two"}],
-          system: @system_info
-        }
-        |> configuration_information
-      end
+      output =
+        capture_io(fn ->
+          %{
+            configuration: %Benchee.Configuration{
+              parallel: 1,
+              time: 60_000_000,
+              warmup: 10_000_000,
+              inputs: nil
+            },
+            scenarios: [%Scenario{job_name: "one"}, %Scenario{job_name: "two"}],
+            system: @system_info
+          }
+          |> configuration_information
+        end)
 
       assert output =~ "warmup: 10 s"
       assert output =~ "time: 1 min"
@@ -66,14 +69,15 @@ defmodule Benchee.Output.BenchmarkPrintertest do
 
     @inputs %{"Arg 1" => "Argument 1", "Arg 2" => "Argument 2"}
     test "multiple inputs" do
-      output = capture_io fn ->
-        %{
-          configuration: %{parallel: 2, time: 10_000, warmup: 0, inputs: @inputs},
-          scenarios: [%Scenario{job_name: "one"}, %Scenario{job_name: "two"}],
-          system: @system_info
-        }
-        |> configuration_information
-      end
+      output =
+        capture_io(fn ->
+          %{
+            configuration: %{parallel: 2, time: 10000, warmup: 0, inputs: @inputs},
+            scenarios: [%Scenario{job_name: "one"}, %Scenario{job_name: "two"}],
+            system: @system_info
+          }
+          |> configuration_information
+        end)
 
       assert output =~ "time: 10 ms"
       assert output =~ "parallel: 2"
@@ -82,10 +86,11 @@ defmodule Benchee.Output.BenchmarkPrintertest do
     end
 
     test "does not print if disabled" do
-      output = capture_io fn ->
-        %{configuration: %{print: %{configuration: false}}}
-        |> configuration_information
-      end
+      output =
+        capture_io(fn ->
+          %{configuration: %{print: %{configuration: false}}}
+          |> configuration_information
+        end)
 
       assert output == ""
     end
@@ -93,17 +98,13 @@ defmodule Benchee.Output.BenchmarkPrintertest do
 
   describe ".benchmarking" do
     test "prints information that it's currently benchmarking" do
-      output = capture_io fn ->
-        benchmarking("Something", %{})
-      end
+      output = capture_io(fn -> benchmarking("Something", %{}) end)
 
       assert output =~ ~r/Benchmarking.+Something/i
     end
 
     test "doesn't print if it's deactivated" do
-      output = capture_io fn ->
-        benchmarking "A", %{print: %{benchmarking: false}}
-      end
+      output = capture_io(fn -> benchmarking("A", %{print: %{benchmarking: false}}) end)
 
       assert output == ""
     end
@@ -111,39 +112,31 @@ defmodule Benchee.Output.BenchmarkPrintertest do
 
   describe ".input_information" do
     test "notifies of the input being used" do
-      output = capture_io fn ->
-        input_information("Big List", %{})
-      end
+      output = capture_io(fn -> input_information("Big List", %{}) end)
 
       assert output =~ ~r/with input Big List/i
     end
 
     test "does nothing when it's the no input marker" do
-      marker = Benchee.Benchmark.no_input
-      output = capture_io fn ->
-        input_information marker, %{}
-      end
+      marker = Benchee.Benchmark.no_input()
+      output = capture_io(fn -> input_information(marker, %{}) end)
 
       assert output == ""
     end
 
     test "does not print if disabled" do
-      output = capture_io fn ->
-        input_information("Big List", %{print: %{benchmarking: false}})
-      end
+      output =
+        capture_io(fn -> input_information("Big List", %{print: %{benchmarking: false}}) end)
 
       assert output == ""
     end
   end
 
   test ".fast_warning warns with reference to more information" do
-    output = capture_io fn ->
-      fast_warning()
-    end
+    output = capture_io(fn -> fast_warning() end)
 
     assert output =~ ~r/fast/i
     assert output =~ ~r/unreliable/i
     assert output =~ "benchee/wiki"
-
   end
 end

--- a/test/benchee/statistics/mode_test.exs
+++ b/test/benchee/statistics/mode_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Statistics.ModeTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Statistics.Mode
+  doctest(Benchee.Statistics.Mode)
 end

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -1,18 +1,17 @@
 defmodule Benchee.StatistcsTest do
   use ExUnit.Case, async: true
   alias Benchee.{Statistics, Suite, Benchmark.Scenario}
-  doctest Benchee.Statistics
+  doctest(Benchee.Statistics)
 
   @sample_1 [600, 470, 170, 430, 300]
   @sample_2 [17, 15, 23, 7, 9, 13]
   describe ".statistics" do
     test "computes the statistics for all jobs correctly" do
       scenarios = [
-        %Scenario{input: "Input", input_name: "Input", job_name: "Job 1",
-                  run_times: @sample_1},
-        %Scenario{input: "Input", input_name: "Input", job_name: "Job 2",
-                  run_times: @sample_2}
+        %Scenario{input: "Input", input_name: "Input", job_name: "Job 1", run_times: @sample_1},
+        %Scenario{input: "Input", input_name: "Input", job_name: "Job 2", run_times: @sample_2}
       ]
+
       suite = %Suite{scenarios: scenarios}
       new_suite = Statistics.statistics(suite)
 
@@ -25,11 +24,10 @@ defmodule Benchee.StatistcsTest do
 
     test "computes statistics correctly for multiple inputs" do
       scenarios = [
-        %Scenario{input: "Input 1", input_name: "Input 1", job_name: "Job",
-                  run_times: @sample_1},
-        %Scenario{input: "Input 2", input_name: "Input 2", job_name: "Job",
-                  run_times: @sample_2}
+        %Scenario{input: "Input 1", input_name: "Input 1", job_name: "Job", run_times: @sample_1},
+        %Scenario{input: "Input 2", input_name: "Input 2", job_name: "Job", run_times: @sample_2}
       ]
+
       suite = %Suite{scenarios: scenarios}
       new_suite = Statistics.statistics(suite)
 
@@ -43,8 +41,10 @@ defmodule Benchee.StatistcsTest do
     @mode_sample [55, 40, 67, 55, 44, 40, 10, 8, 55, 90, 67]
     test "mode is calculated correctly" do
       scenarios = [%Scenario{run_times: @mode_sample}]
-      suite = %Suite{scenarios: scenarios}
-              |> Statistics.statistics
+
+      suite =
+        %Suite{scenarios: scenarios}
+        |> Statistics.statistics()
 
       [%Scenario{run_time_statistics: stats}] = suite.scenarios
       assert stats.mode == 55
@@ -56,14 +56,15 @@ defmodule Benchee.StatistcsTest do
         configuration: %{formatters: []}
       }
 
-      assert %Suite{configuration: %{formatters: []}} =
-        Statistics.statistics suite
+      assert %Suite{configuration: %{formatters: []}} = Statistics.statistics(suite)
     end
 
     defp stats_for(suite, job_name, input_name) do
-      %Scenario{run_time_statistics: stats} = Enum.find(suite.scenarios, fn(scenario) ->
-        scenario.job_name == job_name && scenario.input_name == input_name
-      end)
+      %Scenario{run_time_statistics: stats} =
+        Enum.find(suite.scenarios, fn scenario ->
+          scenario.job_name == job_name && scenario.input_name == input_name
+        end)
+
       stats
     end
 

--- a/test/benchee/suite_test.exs
+++ b/test/benchee/suite_test.exs
@@ -16,10 +16,11 @@ defmodule Benchee.SuiteTest do
       }
 
       result = deep_merge(@original, override)
+
       assert %Suite{
-        system: %{elixir: "1.5.0-dev", erlang: "19.2"},
-        scenarios: []
-      } = result
+               system: %{elixir: "1.5.0-dev", erlang: "19.2"},
+               scenarios: []
+             } = result
     end
 
     test "merges with a map" do
@@ -30,14 +31,12 @@ defmodule Benchee.SuiteTest do
       result = deep_merge(@original, override)
 
       assert %Suite{
-        system: %{elixir: "1.5.0-dev", erlang: "19.2"}
-      } = result
+               system: %{elixir: "1.5.0-dev", erlang: "19.2"}
+             } = result
     end
 
     test "raises when anything else is tried" do
-      assert_raise FunctionClauseError, fn ->
-        deep_merge @original, "lol this doesn't fit"
-      end
+      assert_raise FunctionClauseError, fn -> deep_merge(@original, "lol this doesn't fit") end
     end
   end
 end

--- a/test/benchee/system_test.exs
+++ b/test/benchee/system_test.exs
@@ -6,8 +6,17 @@ defmodule Benchee.SystemTest do
 
   test ".system adds the content to a given suite" do
     system_info = Benchee.System.system(%Suite{})
-    assert %{system: %{elixir: _, erlang: _, num_cores: _, os: _,
-                       cpu_speed: _, available_memory: _}} = system_info
+
+    assert %{
+             system: %{
+               elixir: _,
+               erlang: _,
+               num_cores: _,
+               os: _,
+               cpu_speed: _,
+               available_memory: _
+             }
+           } = system_info
   end
 
   test ".elixir returns the current elixir version" do
@@ -62,25 +71,25 @@ defmodule Benchee.SystemTest do
 
   test ".available_memory returns the available memory on the computer" do
     {num, rest} = Float.parse(Benchee.System.available_memory())
-    decimal_part_of_available_memory = "#{num}"
-      |> String.split( ".")
+
+    decimal_part_of_available_memory =
+      "#{num}"
+      |> String.split(".")
       |> Enum.at(1)
       |> String.length()
+
     assert num > 0
     assert decimal_part_of_available_memory <= 2
     assert rest =~ ~r/GB/
   end
 
   test ".system_cmd handles errors gracefully" do
-    system_func = fn(_, _) -> {"ERROR", 1} end
-    captured_io = capture_io(fn ->
-      Benchee.System.system_cmd("cat", "dev/null", system_func)
-    end)
+    system_func = fn _, _ -> {"ERROR", 1} end
+    captured_io = capture_io(fn -> Benchee.System.system_cmd("cat", "dev/null", system_func) end)
 
     assert captured_io =~ "Something went wrong"
     assert captured_io =~ "ERROR"
-    capture_io fn ->
-      assert Benchee.System.system_cmd("cat", "dev/null", system_func) == "N/A"
-    end
+
+    capture_io(fn -> assert Benchee.System.system_cmd("cat", "dev/null", system_func) == "N/A" end)
   end
 end

--- a/test/benchee/utility/deep_convert_test.exs
+++ b/test/benchee/utility/deep_convert_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Utility.DeepConvertTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Utility.DeepConvert
+  doctest(Benchee.Utility.DeepConvert)
 end

--- a/test/benchee/utility/file_creation_integration_test.exs
+++ b/test/benchee/utility/file_creation_integration_test.exs
@@ -9,45 +9,46 @@ defmodule Benchee.Utility.FileCreationIntegrationTest do
   @file_name_2 "#{@directory}/test_big_list.txt"
   @input_to_contents %{
     "small input" => "abc",
-    "Big list"    => "ABC"
+    "Big list" => "ABC"
   }
 
   describe ".each" do
     test "writes file contents just fine" do
       try do
-        each(@input_to_contents, @filename, fn(file, content, _) ->
-          :ok = IO.write file, content
+        each(@input_to_contents, @filename, fn file, content, _ ->
+          :ok = IO.write(file, content)
         end)
+
         assert_correct_files()
       after
-        File.rm_rf! @directory
+        File.rm_rf!(@directory)
       end
     end
 
     test "by default writes writes files" do
       try do
-        capture_io fn -> each @input_to_contents, @filename end
+        capture_io(fn -> each(@input_to_contents, @filename) end)
         assert_correct_files()
       after
-        File.rm_rf! @directory
+        File.rm_rf!(@directory)
       end
     end
 
     test "by default prints out filenames" do
       try do
-        output = capture_io fn -> each @input_to_contents, @filename end
+        output = capture_io(fn -> each(@input_to_contents, @filename) end)
 
         assert output =~ @file_name_1
         assert output =~ @file_name_2
       after
-        File.rm_rf! @directory
+        File.rm_rf!(@directory)
       end
     end
 
     defp assert_correct_files do
-      assert File.exists? @file_name_1
-      assert File.exists? @file_name_2
-      refute File.exists? "#{@directory}/test"
+      assert File.exists?(@file_name_1)
+      assert File.exists?(@file_name_2)
+      refute File.exists?("#{@directory}/test")
 
       assert File.read!(@file_name_1) == "abc"
       assert File.read!(@file_name_2) == "ABC"
@@ -55,17 +56,18 @@ defmodule Benchee.Utility.FileCreationIntegrationTest do
 
     test "is passed the filenames" do
       try do
-        {:ok, agent} = Agent.start fn -> [] end
-        each(@input_to_contents, @filename, fn(file, content, filename) ->
-          :ok = IO.write file, content
-          Agent.update agent, fn(state) -> [filename | state] end
+        {:ok, agent} = Agent.start(fn -> [] end)
+
+        each(@input_to_contents, @filename, fn file, content, filename ->
+          :ok = IO.write(file, content)
+          Agent.update(agent, fn state -> [filename | state] end)
         end)
 
-        file_names = Agent.get agent, fn(state) -> state end
+        file_names = Agent.get(agent, fn state -> state end)
         assert Enum.member?(file_names, @file_name_1)
         assert Enum.member?(file_names, @file_name_2)
       after
-        File.rm_rf! @directory
+        File.rm_rf!(@directory)
       end
     end
   end

--- a/test/benchee/utility/file_creation_test.exs
+++ b/test/benchee/utility/file_creation_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Utility.FileCreationTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Utility.FileCreation
+  doctest(Benchee.Utility.FileCreation)
 end

--- a/test/benchee/utility/repeat_n_test.exs
+++ b/test/benchee/utility/repeat_n_test.exs
@@ -3,19 +3,19 @@ defmodule Benchee.Utility.RepeatNTest do
   import Benchee.Utility.RepeatN
 
   test "calls it n times" do
-    assert_called_n 10
+    assert_called_n(10)
   end
 
   test "calls it only one time when 1 is specified" do
-    assert_called_n 1
+    assert_called_n(1)
   end
 
   test "calls it 0 times when 0 is specified" do
-    assert_called_n 0
+    assert_called_n(0)
   end
 
   defp assert_called_n(n) do
-    repeat_n(fn -> send self(), :called end, n)
+    repeat_n(fn -> send(self(), :called) end, n)
 
     assert_called_exactly_times(n)
   end
@@ -23,7 +23,8 @@ defmodule Benchee.Utility.RepeatNTest do
   defp assert_called_exactly_times(n) when n <= 0 do
     refute_receive :called
   end
+
   defp assert_called_exactly_times(n) do
-    Enum.each(Enum.to_list(1..n), fn (_)-> assert_receive :called end)
+    Enum.each(Enum.to_list(1..n), fn _ -> assert_receive :called end)
   end
 end

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -2,43 +2,44 @@ defmodule BencheeTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureIO
   import Benchee.TestHelpers
-  doctest Benchee
+  doctest(Benchee)
 
   @header_regex ~r/^Name.+ips.+average.+deviation.+median$/m
-  @test_times   [time: 0.01, warmup: 0.005]
+  @test_times [time: 0.01, warmup: 0.005]
   test "integration step by step" do
-    capture_io fn ->
+    capture_io(fn ->
       result =
         Benchee.init(@test_times)
-        |> Benchee.system
+        |> Benchee.system()
         |> Benchee.benchmark("Sleeps", fn -> :timer.sleep(10) end)
-        |> Benchee.measure
-        |> Benchee.Statistics.statistics
-        |> Benchee.Formatters.Console.format
+        |> Benchee.measure()
+        |> Benchee.Statistics.statistics()
+        |> Benchee.Formatters.Console.format()
 
       [[_input_name, header, benchmark_stats]] = result
       assert Regex.match?(@header_regex, header)
       assert Regex.match?(body_regex("Sleeps"), benchmark_stats)
-    end
+    end)
   end
 
   test "integration high level interface .run" do
-    output = capture_io fn ->
-      Benchee.run(%{"Sleeps" => fn -> :timer.sleep(10) end}, @test_times)
-    end
+    output =
+      capture_io(fn -> Benchee.run(%{"Sleeps" => fn -> :timer.sleep(10) end}, @test_times) end)
 
     assert Regex.match?(@header_regex, output)
     assert Regex.match?(body_regex("Sleeps"), output)
-    refute Regex.match? ~r/Compariosn/, output
-    refute Regex.match? ~r/x slower/, output
+    refute Regex.match?(~r/Compariosn/, output)
+    refute Regex.match?(~r/x slower/, output)
   end
 
   test "integration multiple funs in .run" do
-    output = capture_io fn ->
-      Benchee.run(%{
-        "Sleeps" => fn -> :timer.sleep(10) end,
-        "Magic"  => fn -> Enum.to_list(1..100) end}, @test_times)
-    end
+    output =
+      capture_io(fn ->
+        Benchee.run(
+          %{"Sleeps" => fn -> :timer.sleep(10) end, "Magic" => fn -> Enum.to_list(1..100) end},
+          @test_times
+        )
+      end)
 
     assert Regex.match?(@header_regex, output)
     assert Regex.match?(body_regex("Sleeps"), output)
@@ -46,74 +47,81 @@ defmodule BencheeTest do
   end
 
   test "integration high level README example old school map config" do
-    output = capture_io fn ->
-      list = Enum.to_list(1..10_000)
-      map_fun = fn(i) -> [i, i * i] end
+    output =
+      capture_io(fn ->
+        list = Enum.to_list(1..10000)
+        map_fun = fn i -> [i, i * i] end
 
-      map_config = Enum.into(@test_times, %{})
-      Benchee.run(map_config, %{
-        "flat_map"    => fn -> Enum.flat_map(list, map_fun) end,
-        "map.flatten" =>
-          fn -> list |> Enum.map(map_fun) |> List.flatten end
-      })
-    end
+        map_config = Enum.into(@test_times, %{})
+
+        Benchee.run(map_config, %{
+          "flat_map" => fn -> Enum.flat_map(list, map_fun) end,
+          "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
+        })
+      end)
 
     readme_sample_asserts(output)
   end
 
   test "integration keywordlist as options in second place" do
-    output = capture_io fn ->
-      list = Enum.to_list(1..10_000)
-      map_fun = fn(i) -> [i, i * i] end
+    output =
+      capture_io(fn ->
+        list = Enum.to_list(1..10000)
+        map_fun = fn i -> [i, i * i] end
 
-      Benchee.run(%{
-        "flat_map"    => fn -> Enum.flat_map(list, map_fun) end,
-        "map.flatten" =>
-          fn -> list |> Enum.map(map_fun) |> List.flatten end
-      }, time: 0.01, warmup: 0.005)
-    end
+        Benchee.run(
+          %{
+            "flat_map" => fn -> Enum.flat_map(list, map_fun) end,
+            "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
+          },
+          time: 0.01,
+          warmup: 0.005
+        )
+      end)
 
-    readme_sample_asserts output
+    readme_sample_asserts(output)
   end
 
   test "erlang style :benchee integration" do
-    output = capture_io fn ->
-      list = Enum.to_list(1..10_000)
-      map_fun = fn(i) -> [i, i * i] end
+    output =
+      capture_io(fn ->
+        list = Enum.to_list(1..10000)
+        map_fun = fn i -> [i, i * i] end
 
-      :benchee.run(%{
-        "flat_map"    => fn -> Enum.flat_map(list, map_fun) end,
-        "map.flatten" =>
-          fn -> list |> Enum.map(map_fun) |> List.flatten end
-      }, time: 0.01, warmup: 0.005)
-    end
+        :benchee.run(
+          %{
+            "flat_map" => fn -> Enum.flat_map(list, map_fun) end,
+            "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
+          },
+          time: 0.01,
+          warmup: 0.005
+        )
+      end)
 
-    readme_sample_asserts output
+    readme_sample_asserts(output)
   end
 
   test "integration expanded README example" do
-    output = capture_io fn ->
-      list = Enum.to_list(1..10_000)
-      map_fun = fn(i) -> [i, i * i] end
+    output =
+      capture_io(fn ->
+        list = Enum.to_list(1..10000)
+        map_fun = fn i -> [i, i * i] end
 
-      Benchee.init(@test_times)
-      |> Benchee.system
-      |> Benchee.benchmark("flat_map", fn -> Enum.flat_map(list, map_fun) end)
-      |> Benchee.benchmark("map.flatten",
-                           fn -> list |> Enum.map(map_fun) |> List.flatten end)
-      |> Benchee.measure
-      |> Benchee.statistics
-      |> Benchee.Formatters.Console.format
-      |> IO.puts
-    end
+        Benchee.init(@test_times)
+        |> Benchee.system()
+        |> Benchee.benchmark("flat_map", fn -> Enum.flat_map(list, map_fun) end)
+        |> Benchee.benchmark("map.flatten", fn -> list |> Enum.map(map_fun) |> List.flatten() end)
+        |> Benchee.measure()
+        |> Benchee.statistics()
+        |> Benchee.Formatters.Console.format()
+        |> IO.puts()
+      end)
 
     readme_sample_asserts(output)
   end
 
   test "integration super fast function print warnings" do
-    output = capture_io fn ->
-      Benchee.run(%{"Sleeps" => fn -> 0 end}, time: 0.001, warmup: 0)
-    end
+    output = capture_io(fn -> Benchee.run(%{"Sleeps" => fn -> 0 end}, time: 0.001, warmup: 0) end)
 
     assert output =~ ~r/fast/
     assert output =~ ~r/unreliable/
@@ -121,48 +129,52 @@ defmodule BencheeTest do
   end
 
   test "integration super fast function warning is printed once per job" do
-    output = capture_io fn ->
-      Benchee.run(%{"Fast" => fn -> 0 end}, time: 0.001, warmup: 0.001)
-    end
+    output =
+      capture_io(fn -> Benchee.run(%{"Fast" => fn -> 0 end}, time: 0.001, warmup: 0.001) end)
 
-    warnings = output
-               |> String.split("\n")
-               |> Enum.filter(fn(line) -> line =~ ~r/Warning.+fast/ end)
+    warnings =
+      output
+      |> String.split("\n")
+      |> Enum.filter(fn line -> line =~ ~r/Warning.+fast/ end)
 
     assert Enum.count(warnings) == 1
   end
 
   test "integration super fast function warnings can be deactivated" do
-    output = capture_io fn ->
-      Benchee.run(%{"Blitz" => fn -> 0 end},
-                  time: 0.001, warmup: 0, print: [fast_warning: false])
-    end
+    output =
+      capture_io(fn ->
+        Benchee.run(%{"Blitz" => fn -> 0 end}, time: 0.001, warmup: 0, print: [
+          fast_warning: false
+        ])
+      end)
 
-    refute Regex.match? ~r/fast/, output
+    refute Regex.match?(~r/fast/, output)
   end
 
   test "integration comparison report can be deactivated" do
-    output = capture_io fn ->
-      Benchee.run(%{"Sleeps"   => fn -> :timer.sleep(10) end,
-                    "Sleeps 2" => fn -> :timer.sleep(20) end},
-                    time: 0.01,
-                    warmup: 0,
-                    console: [comparison: false])
-    end
+    output =
+      capture_io(fn ->
+        Benchee.run(
+          %{"Sleeps" => fn -> :timer.sleep(10) end, "Sleeps 2" => fn -> :timer.sleep(20) end},
+          time: 0.01,
+          warmup: 0,
+          console: [comparison: false]
+        )
+      end)
 
     refute output =~ ~r/compar/i
   end
 
   test "multiple formatters can be configured and are all called" do
-    output = capture_io fn ->
-      Benchee.run(%{
-        "Sleeps" => fn -> :timer.sleep(10) end},
-        time:       0.01,
-        warmup:     0.01,
-        formatters: [fn(_) -> IO.puts "Formatter one" end,
-                     fn(_) -> IO.puts "Formatter two" end]
-      )
-    end
+    output =
+      capture_io(fn ->
+        Benchee.run(
+          %{"Sleeps" => fn -> :timer.sleep(10) end},
+          time: 0.01,
+          warmup: 0.01,
+          formatters: [fn _ -> IO.puts("Formatter one") end, fn _ -> IO.puts("Formatter two") end]
+        )
+      end)
 
     assert output =~ "Formatter one"
     assert output =~ "Formatter two"
@@ -170,188 +182,233 @@ defmodule BencheeTest do
 
   @rough_10_milli_s "((8|9|10|11|12|13|14)\\.\\d{2} ms)"
   test "formatters have full access to the suite data, values in assigns" do
-    retrying fn ->
-      formatter_one = fn(suite) ->
-        run_time = suite.scenarios
-                   |> (fn([scenario | _]) -> List.last(scenario.run_times) end).()
-                   |> Benchee.Conversion.Duration.format
+    retrying(fn ->
+      formatter_one = fn suite ->
+        run_time =
+          suite.scenarios
+          |> (fn [scenario | _] -> List.last(scenario.run_times) end).()
+          |> Benchee.Conversion.Duration.format()
 
-        IO.puts "Run time: #{run_time}"
+        IO.puts("Run time: #{run_time}")
       end
 
-      formatter_two = fn(suite) ->
-        average = suite.scenarios
-                  |> (fn([scenario | _]) -> scenario.run_time_statistics.average end).()
-                  |> Benchee.Conversion.Duration.format
-        IO.puts "Average: #{average}"
+      formatter_two = fn suite ->
+        average =
+          suite.scenarios
+          |> (fn [scenario | _] -> scenario.run_time_statistics.average end).()
+          |> Benchee.Conversion.Duration.format()
+
+        IO.puts("Average: #{average}")
       end
 
-      formatter_three = fn(suite) ->
-        IO.puts suite.configuration.assigns.custom
-      end
+      formatter_three = fn suite -> IO.puts(suite.configuration.assigns.custom) end
 
-      output = capture_io fn ->
-        Benchee.run(%{"Sleeps" => fn -> :timer.sleep(10) end},
-          time:       0.01,
-          warmup:     0.005,
-          assigns:   %{custom: "Custom value"},
-          formatters: [formatter_one, formatter_two, formatter_three]
-        )
-      end
+      output =
+        capture_io(fn ->
+          Benchee.run(
+            %{"Sleeps" => fn -> :timer.sleep(10) end},
+            time: 0.01,
+            warmup: 0.005,
+            assigns: %{custom: "Custom value"},
+            formatters: [formatter_one, formatter_two, formatter_three]
+          )
+        end)
 
       assert output =~ ~r/Run time: #{@rough_10_milli_s}$/m
       assert output =~ ~r/Average: #{@rough_10_milli_s}$/m
       assert output =~ "Custom value"
-    end
+    end)
   end
 
   test "inputs feature version of readme example" do
-    output = capture_io fn ->
-      map_fun = fn(i) -> [i, i * i] end
+    output =
+      capture_io(fn ->
+        map_fun = fn i -> [i, i * i] end
 
-      configuration = Keyword.merge @test_times,
-                                    inputs: %{"list" => Enum.to_list(1..10_000)}
+        configuration = Keyword.merge(@test_times, inputs: %{"list" => Enum.to_list(1..10000)})
 
-      Benchee.run(%{
-        "flat_map"    => fn(input) -> Enum.flat_map(input, map_fun) end,
-        "map.flatten" =>
-          fn(input) -> input |> Enum.map(map_fun) |> List.flatten end
-      }, configuration)
-    end
+        Benchee.run(
+          %{
+            "flat_map" => fn input -> Enum.flat_map(input, map_fun) end,
+            "map.flatten" => fn input -> input |> Enum.map(map_fun) |> List.flatten() end
+          },
+          configuration
+        )
+      end)
 
     readme_sample_asserts(output)
   end
 
   test "multiple inputs" do
-    output = capture_io fn ->
-      map_fun = fn(i) -> [i, i * i] end
-      inputs = [
-        inputs: %{
-          "small list"  => Enum.to_list(1..100),
-          "medium list" => Enum.to_list(1..1_000),
-          "bigger list" => Enum.to_list(1..10_000),
-        }
-      ]
+    output =
+      capture_io(fn ->
+        map_fun = fn i -> [i, i * i] end
 
-      configuration = Keyword.merge @test_times, inputs
+        inputs = [
+          inputs: %{
+            "small list" => Enum.to_list(1..100),
+            "medium list" => Enum.to_list(1..1000),
+            "bigger list" => Enum.to_list(1..10000)
+          }
+        ]
 
+        configuration = Keyword.merge(@test_times, inputs)
 
-      Benchee.run(%{
-        "flat_map"    => fn(input) -> Enum.flat_map(input, map_fun) end,
-        "map.flatten" =>
-          fn(input) -> input |> Enum.map(map_fun) |> List.flatten end
-      }, configuration)
-    end
+        Benchee.run(
+          %{
+            "flat_map" => fn input -> Enum.flat_map(input, map_fun) end,
+            "map.flatten" => fn input -> input |> Enum.map(map_fun) |> List.flatten() end
+          },
+          configuration
+        )
+      end)
 
-    assert String.contains? output, ["small list", "medium list", "bigger list"]
-    occurences = Regex.scan body_regex("flat_map"), output
+    assert String.contains?(output, ["small list", "medium list", "bigger list"])
+    occurences = Regex.scan(body_regex("flat_map"), output)
     assert length(occurences) == 3
   end
 
   test "multiple inputs with very fast functions" do
-    output = capture_io fn ->
-      inputs = [inputs: %{"number_one" => 1, :symbole_one => :one}]
+    output =
+      capture_io(fn ->
+        inputs = [inputs: %{"number_one" => 1, :symbole_one => :one}]
 
-      configuration = Keyword.merge @test_times, inputs
+        configuration = Keyword.merge(@test_times, inputs)
 
-      Benchee.run(%{
-        "identity" => fn(i) -> i end
-      }, configuration)
-    end
+        Benchee.run(
+          %{
+            "identity" => fn i -> i end
+          },
+          configuration
+        )
+      end)
 
     assert Regex.match?(@header_regex, output)
-    assert Regex.match? ~r/fast/, output
-    assert Regex.match? ~r/unreliable/, output
+    assert Regex.match?(~r/fast/, output)
+    assert Regex.match?(~r/unreliable/, output)
 
-    assert String.contains? output, ["number_one", "symbol_one"]
-    occurences = Regex.scan body_regex("identity"), output
+    assert String.contains?(output, ["number_one", "symbol_one"])
+    occurences = Regex.scan(body_regex("identity"), output)
     assert length(occurences) == 2
   end
 
   test ".run returns the suite intact" do
-    capture_io fn ->
-      suite = Benchee.run(%{
-        "sleep"    => fn -> :timer.sleep 1 end
-      }, time: 0.001, warmup: 0)
+    capture_io(fn ->
+      suite =
+        Benchee.run(
+          %{
+            "sleep" => fn -> :timer.sleep(1) end
+          },
+          time: 0.001,
+          warmup: 0
+        )
+
       assert %Benchee.Suite{scenarios: _, configuration: _} = suite
-    end
+    end)
   end
 
   test ".run also adds system information into the mix via Benchee.System" do
-    capture_io fn ->
-      suite = Benchee.run(%{
-        "sleep"    => fn -> :timer.sleep 1 end
-      }, time: 0.001, warmup: 0)
-      elixir = Benchee.System.elixir
-      erlang = Benchee.System.erlang
+    capture_io(fn ->
+      suite =
+        Benchee.run(
+          %{
+            "sleep" => fn -> :timer.sleep(1) end
+          },
+          time: 0.001,
+          warmup: 0
+        )
+
+      elixir = Benchee.System.elixir()
+      erlang = Benchee.System.erlang()
 
       assert %{system: %{elixir: ^elixir, erlang: ^erlang}} = suite
-    end
+    end)
   end
 
   test ".run accepts atom keys for jobs" do
-    capture_io fn ->
-      suite = Benchee.run(%{
-        sleep: fn -> :timer.sleep 1 end
-      }, time: 0.001, warmup: 0)
+    capture_io(fn ->
+      suite =
+        Benchee.run(
+          %{
+            sleep: fn -> :timer.sleep(1) end
+          },
+          time: 0.001,
+          warmup: 0
+        )
 
-      assert Enum.map(suite.scenarios, &(&1.job_name)) == ~w(sleep)
-    end
+      assert Enum.map(suite.scenarios, & &1.job_name) == ~w(sleep)
+    end)
   end
 
   test ".run accepts atom keys for inputs" do
-    output = capture_io fn ->
-      map_fun = fn(i) -> [i, i * i] end
-      inputs = [
-        inputs: %{
-          "small list"  => Enum.to_list(1..100),
-          mediumList:      Enum.to_list(1..1_000)
-        }
-      ]
+    output =
+      capture_io(fn ->
+        map_fun = fn i -> [i, i * i] end
 
-      configuration = Keyword.merge @test_times, inputs
+        inputs = [
+          inputs: %{
+            "small list" => Enum.to_list(1..100),
+            mediumList: Enum.to_list(1..1000)
+          }
+        ]
 
-      Benchee.run(%{
-        "flat_map"    => fn(input) -> Enum.flat_map(input, map_fun) end,
-        "map.flatten" =>
-          fn(input) -> input |> Enum.map(map_fun) |> List.flatten end
-      }, configuration)
-    end
+        configuration = Keyword.merge(@test_times, inputs)
 
-    assert String.contains? output, ["small list", "mediumList"]
-    occurences = Regex.scan body_regex("flat_map"), output
+        Benchee.run(
+          %{
+            "flat_map" => fn input -> Enum.flat_map(input, map_fun) end,
+            "map.flatten" => fn input -> input |> Enum.map(map_fun) |> List.flatten() end
+          },
+          configuration
+        )
+      end)
+
+    assert String.contains?(output, ["small list", "mediumList"])
+    occurences = Regex.scan(body_regex("flat_map"), output)
     assert length(occurences) == 2
   end
 
   describe "hooks" do
     test "it runs all of them" do
-      capture_io fn ->
+      capture_io(fn ->
         myself = self()
-        Benchee.run %{
-          "sleeper"   => {
-            fn -> :timer.sleep 1 end,
-            before_each: fn -> send myself, :local_before end,
-            after_each:  fn(_) -> send myself, :local_after end,
-            before_scenario: fn -> send myself, :local_before_scenario end,
-            after_scenario: fn -> send myself, :local_after_scenario end},
-          "sleeper 2" => fn -> :timer.sleep 1 end
-        }, time: 0.0001,
-           warmup: 0,
-           before_each: fn -> send myself, :global_before end,
-           after_each:  fn(_) -> send myself, :global_after end,
-           before_scenario: fn -> send myself, :global_before_scenario end,
-           after_scenario:  fn -> send myself, :global_after_scenario end
-      end
 
-      assert_received_exactly [
+        Benchee.run(
+          %{
+            "sleeper" => {
+              fn -> :timer.sleep(1) end,
+              before_each: fn -> send(myself, :local_before) end,
+              after_each: fn _ -> send(myself, :local_after) end,
+              before_scenario: fn -> send(myself, :local_before_scenario) end,
+              after_scenario: fn -> send(myself, :local_after_scenario) end
+            },
+            "sleeper 2" => fn -> :timer.sleep(1) end
+          },
+          time: 0.0001,
+          warmup: 0,
+          before_each: fn -> send(myself, :global_before) end,
+          after_each: fn _ -> send(myself, :global_after) end,
+          before_scenario: fn -> send(myself, :global_before_scenario) end,
+          after_scenario: fn -> send(myself, :global_after_scenario) end
+        )
+      end)
+
+      assert_received_exactly([
         # first job with all those local hooks
-        :global_before_scenario, :local_before_scenario, :global_before,
-        :local_before, :local_after, :global_after, :local_after_scenario,
+        :global_before_scenario,
+        :local_before_scenario,
+        :global_before,
+        :local_before,
+        :local_after,
+        :global_after,
+        :local_after_scenario,
         :global_after_scenario,
         # second job that only runs global hooks
-        :global_before_scenario, :global_before, :global_after,
+        :global_before_scenario,
+        :global_before,
+        :global_after,
         :global_after_scenario
-      ]
+      ])
     end
   end
 

--- a/test/support/fake_benchmark_printer.ex
+++ b/test/support/fake_benchmark_printer.ex
@@ -1,21 +1,21 @@
 defmodule Benchee.Test.FakeBenchmarkPrinter do
   def duplicate_benchmark_warning(name) do
-    send self(), {:duplicate, name}
+    send(self(), {:duplicate, name})
   end
 
   def configuration_information(_) do
-    send self(), :configuration_information
+    send(self(), :configuration_information)
   end
 
   def benchmarking(name, _) do
-    send self(), {:benchmarking, name}
+    send(self(), {:benchmarking, name})
   end
 
   def fast_warning do
-    send self(), :fast_warning
+    send(self(), :fast_warning)
   end
 
   def input_information(name, _config) do
-    send self(), {:input_information, name}
+    send(self(), {:input_information, name})
   end
 end

--- a/test/support/fake_benchmark_runner.ex
+++ b/test/support/fake_benchmark_runner.ex
@@ -1,7 +1,8 @@
 defmodule Benchee.Test.FakeBenchmarkRunner do
   def run_scenarios(scenarios, scenario_context) do
-    send self(), {:run_scenarios, scenarios, scenario_context}
-    Enum.map(scenarios, fn(scenario) ->
+    send(self(), {:run_scenarios, scenarios, scenario_context})
+
+    Enum.map(scenarios, fn scenario ->
       %Benchee.Benchmark.Scenario{scenario | run_times: [1.0]}
     end)
   end

--- a/test/support/fake_formatter.ex
+++ b/test/support/fake_formatter.ex
@@ -4,6 +4,6 @@ defmodule Benchee.Test.FakeFormatter do
   end
 
   def write(output) do
-    send self(), {:write, output}
+    send(self(), {:write, output})
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -6,9 +6,11 @@ defmodule Benchee.TestHelpers do
   # retry tests that are doing actual benchmarking and are flaky
   # on overloaded and/or slower systems
   def retrying(asserting_function, n \\ @default_retries)
+
   def retrying(asserting_function, 1) do
     asserting_function.()
   end
+
   def retrying(asserting_function, n) do
     try do
       asserting_function.()
@@ -20,10 +22,10 @@ defmodule Benchee.TestHelpers do
 
   # assert we received eactly those messages of the contained types
   def assert_received_exactly(expected) do
-    Enum.each(expected, fn(message) -> assert_received ^message end)
+    Enum.each(expected, fn message -> assert_received ^message end)
 
     expected
-    |> Enum.uniq
-    |> Enum.each(fn(message) -> refute_received(^message) end)
+    |> Enum.uniq()
+    |> Enum.each(fn message -> refute_received ^message end)
   end
 end


### PR DESCRIPTION
This is a big diff of course, but it's hopefully a one time deal. Once
1.6 is officially released we can add a check to CI to ensure all newly
committed code is properly formatted, but for now I'm leaving that CI
check out.