### PR TITLE
Add nth percentile calculation

### DIFF
--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -44,12 +44,12 @@ defmodule Benchee.Formatters.Console do
   iex> scenarios = [
   ...>   %Benchee.Benchmark.Scenario{
   ...>     job_name: "My Job", input_name: "My input", run_time_statistics: %Benchee.Statistics{
-  ...>       average: 200.0, ips: 5000.0,std_dev_ratio: 0.1, median: 190.0
+  ...>       average: 200.0,ips: 5000.0,std_dev_ratio: 0.1, median: 190.0, percentiles: %{99 => 300.1}
   ...>     }
   ...>   },
   ...>   %Benchee.Benchmark.Scenario{
   ...>     job_name: "Job 2", input_name: "My input", run_time_statistics: %Benchee.Statistics{
-  ...>       average: 400.0, ips: 2500.0, std_dev_ratio: 0.2, median: 390.0
+  ...>       average: 400.0, ips: 2500.0, std_dev_ratio: 0.2, median: 390.0, percentiles: %{99 => 500.1}
   ...>     }
   ...>   }
   ...> ]
@@ -64,8 +64,8 @@ defmodule Benchee.Formatters.Console do
   ...> }
   iex> Benchee.Formatters.Console.format(suite)
   [["\n##### With input My input #####", "\nName             ips        average  deviation         median         99th %\n",
-  "My Job           5 K         200 μs    ±10.00%         190 μs\n",
-  "Job 2         2.50 K         400 μs    ±20.00%         390 μs\n"]]
+  "My Job           5 K         200 μs    ±10.00%         190 μs      300.10 μs\n",
+  "Job 2         2.50 K         400 μs    ±20.00%         390 μs      500.10 μs\n"]]
 
   ```
 
@@ -118,20 +118,20 @@ defmodule Benchee.Formatters.Console do
   iex> scenarios = [
   ...>   %Benchee.Benchmark.Scenario{
   ...>     job_name: "My Job", run_time_statistics: %Benchee.Statistics{
-  ...>       average: 200.0, ips: 5000.0,std_dev_ratio: 0.1, median: 190.0
+  ...>       average: 200.0, ips: 5000.0,std_dev_ratio: 0.1, median: 190.0, percentiles: %{99 => 300.1}
   ...>     }
   ...>   },
   ...>   %Benchee.Benchmark.Scenario{
   ...>     job_name: "Job 2", run_time_statistics: %Benchee.Statistics{
-  ...>       average: 400.0, ips: 2500.0, std_dev_ratio: 0.2, median: 390.0
+  ...>       average: 400.0, ips: 2500.0, std_dev_ratio: 0.2, median: 390.0, percentiles: %{99 => 500.1}
   ...>     }
   ...>   }
   ...> ]
   iex> configuration = %{comparison: false, unit_scaling: :best}
   iex> Benchee.Formatters.Console.format_scenarios(scenarios, configuration)
   ["\nName             ips        average  deviation         median         99th %\n",
-  "My Job           5 K         200 μs    ±10.00%         190 μs\n",
-  "Job 2         2.50 K         400 μs    ±20.00%         390 μs\n"]
+  "My Job           5 K         200 μs    ±10.00%         190 μs      300.10 μs\n",
+  "Job 2         2.50 K         400 μs    ±20.00%         390 μs      500.10 μs\n"]
 
   ```
 
@@ -194,17 +194,21 @@ defmodule Benchee.Formatters.Console do
                            average:       average,
                            ips:           ips,
                            std_dev_ratio: std_dev_ratio,
-                           median:        median
+                           median:        median,
+                           percentiles:   %{99 => percentile_99}
                          }
                        },
                        %{run_time: run_time_unit,
                          ips:      ips_unit,
                        }, label_width) do
-    "~*s~*ts~*ts~*ts~*ts\n"
-    |> :io_lib.format([-label_width, name, @ips_width, ips_out(ips, ips_unit),
-                       @average_width, run_time_out(average, run_time_unit),
-                       @deviation_width, deviation_out(std_dev_ratio),
-                       @median_width, run_time_out(median, run_time_unit)])
+    "~*s~*ts~*ts~*ts~*ts~*ts\n"
+    |> :io_lib.format([
+      -label_width, name,
+      @ips_width, ips_out(ips, ips_unit),
+      @average_width, run_time_out(average, run_time_unit),
+      @deviation_width, deviation_out(std_dev_ratio),
+      @median_width, run_time_out(median, run_time_unit),
+      @percentile_width, run_time_out(percentile_99, run_time_unit)])
     |> to_string
   end
 

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -16,6 +16,7 @@ defmodule Benchee.Formatters.Console do
   @average_width 15
   @deviation_width 11
   @median_width 15
+  @percentile_width 15
 
   @doc """
   Formats the benchmark statistics using `Benchee.Formatters.Console.format/1`
@@ -62,7 +63,7 @@ defmodule Benchee.Formatters.Console do
   ...>   }
   ...> }
   iex> Benchee.Formatters.Console.format(suite)
-  [["\n##### With input My input #####", "\nName             ips        average  deviation         median\n",
+  [["\n##### With input My input #####", "\nName             ips        average  deviation         median            P99\n",
   "My Job           5 K         200 μs    ±10.00%         190 μs\n",
   "Job 2         2.50 K         400 μs    ±20.00%         390 μs\n"]]
 
@@ -128,7 +129,7 @@ defmodule Benchee.Formatters.Console do
   ...> ]
   iex> configuration = %{comparison: false, unit_scaling: :best}
   iex> Benchee.Formatters.Console.format_scenarios(scenarios, configuration)
-  ["\nName             ips        average  deviation         median\n",
+  ["\nName             ips        average  deviation         median            P99\n",
   "My Job           5 K         200 μs    ±10.00%         190 μs\n",
   "Job 2         2.50 K         400 μs    ±20.00%         390 μs\n"]
 
@@ -147,10 +148,11 @@ defmodule Benchee.Formatters.Console do
   end
 
   defp column_descriptors(label_width) do
-    "\n~*s~*s~*s~*s~*s\n"
+    "\n~*s~*s~*s~*s~*s~*s\n"
     |> :io_lib.format([-label_width, "Name", @ips_width, "ips",
                        @average_width, "average",
-                       @deviation_width, "deviation", @median_width, "median"])
+                       @deviation_width, "deviation", @median_width, "median",
+                       @percentile_width, "P99"])
     |> to_string
   end
 

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -63,7 +63,7 @@ defmodule Benchee.Formatters.Console do
   ...>   }
   ...> }
   iex> Benchee.Formatters.Console.format(suite)
-  [["\n##### With input My input #####", "\nName             ips        average  deviation         median            P99\n",
+  [["\n##### With input My input #####", "\nName             ips        average  deviation         median         99th %\n",
   "My Job           5 K         200 μs    ±10.00%         190 μs\n",
   "Job 2         2.50 K         400 μs    ±20.00%         390 μs\n"]]
 
@@ -129,7 +129,7 @@ defmodule Benchee.Formatters.Console do
   ...> ]
   iex> configuration = %{comparison: false, unit_scaling: :best}
   iex> Benchee.Formatters.Console.format_scenarios(scenarios, configuration)
-  ["\nName             ips        average  deviation         median            P99\n",
+  ["\nName             ips        average  deviation         median         99th %\n",
   "My Job           5 K         200 μs    ±10.00%         190 μs\n",
   "Job 2         2.50 K         400 μs    ±20.00%         390 μs\n"]
 
@@ -152,7 +152,7 @@ defmodule Benchee.Formatters.Console do
     |> :io_lib.format([-label_width, "Name", @ips_width, "ips",
                        @average_width, "average",
                        @deviation_width, "deviation", @median_width, "median",
-                       @percentile_width, "P99"])
+                       @percentile_width, "99th %"])
     |> to_string
   end
 

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -160,7 +160,7 @@ defmodule Benchee.Statistics do
     deviation           = standard_deviation(run_times, average, iterations)
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
-    median              = Percentile.percentile(run_times, iterations, 50)
+    median              = Percentile.percentile(run_times, 50)
     mode                = Mode.mode(run_times)
     minimum             = Enum.min run_times
     maximum             = Enum.max run_times

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -5,6 +5,7 @@ defmodule Benchee.Statistics do
   """
 
   alias Benchee.Statistics.Mode
+  alias Benchee.Statistics.Percentile
 
   defstruct [:average, :ips, :std_dev, :std_dev_ratio, :std_dev_ips, :median,
              :mode, :minimum, :maximum, :sample_size]
@@ -159,7 +160,7 @@ defmodule Benchee.Statistics do
     deviation           = standard_deviation(run_times, average, iterations)
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
-    median              = Benchee.Statistics.Percentile.percentile(run_times, iterations, 50)
+    median              = Percentile.percentile(run_times, iterations, 50)
     mode                = Mode.mode(run_times)
     minimum             = Enum.min run_times
     maximum             = Enum.max run_times

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -17,7 +17,7 @@ defmodule Benchee.Statistics do
     std_dev_ratio: float,
     std_dev_ips: float,
     median: number,
-    percentiles: %{number => number},
+    percentiles: %{number => float},
     mode: number,
     minimum: number,
     maximum: number,

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -159,7 +159,7 @@ defmodule Benchee.Statistics do
     deviation           = standard_deviation(run_times, average, iterations)
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
-    median              = compute_median(run_times, iterations)
+    median              = Benchee.Statistics.Percentile.percentile(run_times, iterations, 50)
     mode                = Mode.mode(run_times)
     minimum             = Enum.min run_times
     maximum             = Enum.max run_times
@@ -188,22 +188,5 @@ defmodule Benchee.Statistics do
     end
     variance = total_variance / iterations
     :math.sqrt variance
-  end
-
-  defp compute_median(run_times, iterations) do
-    # this is rather inefficient, as O(log(n) * n + n) - there are
-    # O(n) algorithms to do compute this should it get to be a problem.
-    sorted = Enum.sort(run_times)
-    middle = div(iterations, 2)
-
-    if Integer.is_odd(iterations) do
-      sorted |> Enum.at(middle) |> to_float
-    else
-      (Enum.at(sorted, middle) + Enum.at(sorted, middle - 1)) / 2
-    end
-  end
-
-  defp to_float(maybe_integer) do
-    :erlang.float maybe_integer
   end
 end

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -8,7 +8,7 @@ defmodule Benchee.Statistics do
   alias Benchee.Statistics.Percentile
 
   defstruct [:average, :ips, :std_dev, :std_dev_ratio, :std_dev_ips, :median,
-             :mode, :minimum, :maximum, :sample_size]
+             :percentiles, :mode, :minimum, :maximum, :sample_size]
 
   @type t :: %__MODULE__{
     average: float,
@@ -17,6 +17,7 @@ defmodule Benchee.Statistics do
     std_dev_ratio: float,
     std_dev_ips: float,
     median: number,
+    percentiles: %{number => number},
     mode: number,
     minimum: number,
     maximum: number,
@@ -68,7 +69,11 @@ defmodule Benchee.Statistics do
     * median        - when all measured times are sorted, this is the middle
       value (or average of the two middle values when the number of times is
       even). More stable than the average and somewhat more likely to be a
-      typical you see.
+      typical value you see.
+    * percentiles   - a map of percentile ranks. These are the values below
+      which x% of the run times lie. For example, 99% of run times are shorter
+      than the 99th percentile (P99) rank.
+      is a value for which 99% of the run times are shorter.
     * mode          - the run time(s) that occur the most. Often one value, but
       can be multiple values if they occur the same amount of times. If no value
       occures at least twice, this value will be nil.
@@ -107,6 +112,7 @@ defmodule Benchee.Statistics do
               std_dev_ratio: 0.4,
               std_dev_ips:   800.0,
               median:        450.0,
+              percentiles:   %{50 => 450.0, 99 => 900.0},
               mode:          400,
               minimum:       200,
               maximum:       900,
@@ -144,6 +150,7 @@ defmodule Benchee.Statistics do
         std_dev_ratio: 0.4,
         std_dev_ips:   800.0,
         median:        450.0,
+        percentiles:   %{50 => 450.0, 99 => 900.0},
         mode:          400,
         minimum:       200,
         maximum:       900,
@@ -160,7 +167,8 @@ defmodule Benchee.Statistics do
     deviation           = standard_deviation(run_times, average, iterations)
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
-    median              = Percentile.percentile(run_times, 50)
+    percentiles         = Percentile.percentile(run_times, [50, 99])
+    median              = Map.get(percentiles, 50)
     mode                = Mode.mode(run_times)
     minimum             = Enum.min run_times
     maximum             = Enum.max run_times
@@ -172,6 +180,7 @@ defmodule Benchee.Statistics do
       std_dev_ratio: standard_dev_ratio,
       std_dev_ips:   standard_dev_ips,
       median:        median,
+      percentiles:   percentiles,
       mode:          mode,
       minimum:       minimum,
       maximum:       maximum,

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -72,7 +72,7 @@ defmodule Benchee.Statistics do
       typical value you see.
     * percentiles   - a map of percentile ranks. These are the values below
       which x% of the run times lie. For example, 99% of run times are shorter
-      than the 99th percentile (P99) rank.
+      than the 99th percentile (99th %) rank.
       is a value for which 99% of the run times are shorter.
     * mode          - the run time(s) that occur the most. Often one value, but
       can be multiple values if they occur the same amount of times. If no value

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -167,8 +167,8 @@ defmodule Benchee.Statistics do
     deviation           = standard_deviation(run_times, average, iterations)
     standard_dev_ratio  = deviation / average
     standard_dev_ips    = ips * standard_dev_ratio
-    percentiles         = Percentile.percentile(run_times, [50, 99])
-    median              = Map.get(percentiles, 50)
+    percentiles         = Percentile.percentiles(run_times, [50, 99])
+    median              = Map.fetch!(percentiles, 50)
     mode                = Mode.mode(run_times)
     minimum             = Enum.min run_times
     maximum             = Enum.max run_times

--- a/lib/benchee/statistics/percentile.ex
+++ b/lib/benchee/statistics/percentile.ex
@@ -1,8 +1,6 @@
 defmodule Benchee.Statistics.Percentile do
   @moduledoc false
 
-  alias Benchee.Statistics
-
   @doc """
   Calculates the value at the `percentile_number`-th percentile. Think of this as the
   value below which `percentile_number` percent of the samples lie. For example,

--- a/lib/benchee/statistics/percentile.ex
+++ b/lib/benchee/statistics/percentile.ex
@@ -1,0 +1,88 @@
+defmodule Benchee.Statistics.Percentile do
+  @moduledoc false
+
+  alias Benchee.Statistics
+
+  @doc """
+  Calculates the value at the `percentile_number`-th percentile. Think of this as the
+  value below which `percentile_number` percent of the samples lie. For example,
+  if `Benchee.Statistics.Percentile.percentile(samples, 99)` == 123.45,
+  99% of samples are less than 123.45.
+
+  ## Examples
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, 100)
+  5.0
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, 150)
+  5.0
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, 0)
+  1.0
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, -1)
+  1.0
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 50)
+  3.0
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 75)
+  4.75
+  """
+  @spec percentile(list(number()), integer()) :: float()
+  def percentile(samples, percentile_number) do
+    percentile(samples, length(samples), percentile_number)
+  end
+
+  @spec percentile(list(number()), integer(), integer()) :: float()
+  def percentile(samples, number_of_samples, percentile_number) when percentile_number > 100 do
+    percentile(samples, number_of_samples, 100)
+  end
+
+  def percentile(samples, number_of_samples, percentile_number) when percentile_number < 0 do
+    percentile(samples, number_of_samples, 0)
+  end
+
+  def percentile(samples, number_of_samples, percentile_number) do
+    sorted = Enum.sort(samples)
+    rank = (percentile_number / 100) * max(0, number_of_samples + 1)
+    percentile_value(sorted, rank)
+  end
+
+  defp percentile_value(sorted, rank) when trunc(rank) == 0 do
+    sorted
+    |> hd
+    |> to_float
+  end
+
+  defp percentile_value(sorted, rank) when trunc(rank) >= length(sorted) do
+    sorted
+    |> Enum.reverse
+    |> hd
+    |> to_float
+  end
+
+  defp percentile_value(sorted, rank) do
+    index = trunc(rank)
+    [lower_bound, upper_bound | _] = Enum.drop(sorted, index - 1)
+    interpolation_value = interpolation_value(lower_bound, upper_bound, rank)
+    lower_bound + interpolation_value
+  end
+
+  # "Type 6" interpolation strategy. There are many ways to interpolate a value
+  # when the rank is not an integer (in other words, we don't exactly land on a
+  # particular sample). Of the 9 main strategies, (types 1-9), types 6, 7, and 8
+  # are generally acceptable and give similar results.
+  #
+  # See also:
+  # - [documentation from R language](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/quantile.html)
+  # - [NIST handbook](http://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm)
+  defp interpolation_value(lower_bound, upper_bound, rank) do
+    interpolation_weight = rank - trunc(rank)
+    interpolation_weight * (upper_bound - lower_bound)
+  end
+
+  defp to_float(maybe_integer) do
+    :erlang.float maybe_integer
+  end
+end

--- a/lib/benchee/statistics/percentile.ex
+++ b/lib/benchee/statistics/percentile.ex
@@ -54,6 +54,10 @@ defmodule Benchee.Statistics.Percentile do
     raise ArgumentError, "percentile must be between 0 and 100, got: #{inspect(percentile_rank)}"
   end
 
+  defp percentile([], _, _) do
+    raise ArgumentError, "can't calculate percentiles on an empty list"
+  end
+
   defp percentile(sorted_samples, number_of_samples, percentile_rank) do
     rank = (percentile_rank / 100) * max(0, number_of_samples + 1)
     percentile_value(sorted_samples, rank)

--- a/lib/benchee/statistics/percentile.ex
+++ b/lib/benchee/statistics/percentile.ex
@@ -9,16 +9,7 @@ defmodule Benchee.Statistics.Percentile do
 
   ## Examples
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, 100)
-  5.0
-
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, 150)
-  5.0
-
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, 0)
-  1.0
-
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 8, -1)
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 12.5)
   1.0
 
   iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 50)
@@ -26,22 +17,23 @@ defmodule Benchee.Statistics.Percentile do
 
   iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 75)
   4.75
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 99)
+  5.0
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 100)
+  ** (ArgumentError) percentile must be between 0 and 100, got: 100
+
+  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 0)
+  ** (ArgumentError) percentile must be between 0 and 100, got: 0
   """
   @spec percentile(list(number()), integer()) :: float()
+  def percentile(_, percentile_number) when percentile_number >= 100 or percentile_number <= 0 do
+    raise ArgumentError, "percentile must be between 0 and 100, got: #{inspect(percentile_number)}"
+  end
+
   def percentile(samples, percentile_number) do
-    percentile(samples, length(samples), percentile_number)
-  end
-
-  @spec percentile(list(number()), integer(), integer()) :: float()
-  def percentile(samples, number_of_samples, percentile_number) when percentile_number > 100 do
-    percentile(samples, number_of_samples, 100)
-  end
-
-  def percentile(samples, number_of_samples, percentile_number) when percentile_number < 0 do
-    percentile(samples, number_of_samples, 0)
-  end
-
-  def percentile(samples, number_of_samples, percentile_number) do
+    number_of_samples = length(samples)
     sorted = Enum.sort(samples)
     rank = (percentile_number / 100) * max(0, number_of_samples + 1)
     percentile_value(sorted, rank)

--- a/lib/benchee/statistics/percentile.ex
+++ b/lib/benchee/statistics/percentile.ex
@@ -72,9 +72,9 @@ defmodule Benchee.Statistics.Percentile do
   # particular sample). Of the 9 main strategies, (types 1-9), types 6, 7, and 8
   # are generally acceptable and give similar results.
   #
-  # See also:
-  # - [documentation from R language](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/quantile.html)
-  # - [NIST handbook](http://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm)
+  # For more information on interpolation strategies, see:
+  # - https://stat.ethz.ch/R-manual/R-devel/library/stats/html/quantile.html
+  # - http://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm
   defp interpolation_value(lower_bound, upper_bound, rank) do
     interpolation_weight = rank - trunc(rank)
     interpolation_weight * (upper_bound - lower_bound)

--- a/lib/benchee/statistics/percentile.ex
+++ b/lib/benchee/statistics/percentile.ex
@@ -17,40 +17,35 @@ defmodule Benchee.Statistics.Percentile do
 
   ## Examples
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 12.5)
-  1.0
+  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 12.5)
+  %{12.5 => 1.0}
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 50)
-  3.0
+  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50])
+  %{50 => 3.0}
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 75)
-  4.75
+  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [75])
+  %{75 => 4.75}
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 99)
-  5.0
+  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 99)
+  %{99 => 5.0}
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], [50, 75, 99])
+  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50, 75, 99])
   %{50 => 3.0, 75 => 4.75, 99 => 5.0}
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 100)
+  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 100)
   ** (ArgumentError) percentile must be between 0 and 100, got: 100
 
-  iex> Benchee.Statistics.Percentile.percentile([5, 3, 4, 5, 1, 3, 1, 3], 0)
+  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 0)
   ** (ArgumentError) percentile must be between 0 and 100, got: 0
   """
-  @spec percentile(list(number()), number() | list(number())) ::
-    percentile | percentiles
-  def percentile(samples, percentile_ranks) do
+  @spec percentiles([number()], number | [number()]) :: percentiles
+  def percentiles(samples, percentile_ranks) do
     number_of_samples = length(samples)
     sorted = Enum.sort(samples)
-    percentile(sorted, number_of_samples, percentile_ranks)
-  end
-
-  defp percentile(sorted_samples, number_of_samples, percentile_ranks)
-    when is_list(percentile_ranks) do
     percentile_ranks
+    |> List.wrap
     |> Enum.reduce(%{}, fn percentile_rank, acc ->
-      perc = percentile(sorted_samples, number_of_samples, percentile_rank)
+      perc = percentile(sorted, number_of_samples, percentile_rank)
       Map.put(acc, percentile_rank, perc)
     end)
   end

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -200,7 +200,7 @@ defmodule Benchee.Formatters.ConsoleTest do
   end
 
   describe ".format" do
-    @header_regex ~r/Name.+ips.+average.+deviation.+median.+P99.*/
+    @header_regex ~r/Name.+ips.+average.+deviation.+median.+99th %.*/
     test "with multiple inputs and just one job" do
       scenarios = [
         %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -16,12 +16,15 @@ defmodule Benchee.Formatters.ConsoleTest do
       scenarios = [
         %Scenario{job_name: "Second", input_name: no_input(), input: no_input(),
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+            percentiles: %{99 => 400.1}
+
           }
         },
         %Scenario{job_name: "First", input_name: no_input(), input: no_input(),
            run_time_statistics: %Statistics{
-            average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
+             average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
+             percentiles: %{99 => 300.1}
            }
         }
       ]
@@ -36,6 +39,8 @@ defmodule Benchee.Formatters.ConsoleTest do
       assert output =~ ~r/5 K/
       assert output =~ ~r/10.00%/
       assert output =~ ~r/195.5/
+      assert output =~ ~r/300.1/
+      assert output =~ ~r/400.1/
     end
   end
 
@@ -43,13 +48,16 @@ defmodule Benchee.Formatters.ConsoleTest do
     test "sorts the the given stats fastest to slowest" do
       scenarios = [
         %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+          percentiles: %{99 => 300.1}
         }},
         %Scenario{job_name: "Third", run_time_statistics: %Statistics{
-          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0
+          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0,
+          percentiles: %{99 => 400.1}
         }},
         %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
+          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
+          percentiles: %{99 => 200.1}
         }},
       ]
 
@@ -64,10 +72,12 @@ defmodule Benchee.Formatters.ConsoleTest do
     test "adjusts the label width to longest name" do
       scenarios = [
         %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0
+          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0,
+          percentiles: %{99 => 400.1}
         }},
         %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+          percentiles: %{99 => 300.1}
         }}
       ]
 
@@ -83,7 +93,8 @@ defmodule Benchee.Formatters.ConsoleTest do
       third_name = String.duplicate("a", third_length)
       long_scenario = %Scenario{
         job_name: third_name, run_time_statistics: %Statistics{
-          average: 400.1, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0
+          average: 400.1, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0,
+          percentiles: %{99 => 500.1}
       }}
       longer_scenarios = scenarios ++ [long_scenario]
 
@@ -100,10 +111,12 @@ defmodule Benchee.Formatters.ConsoleTest do
     test "creates comparisons" do
       scenarios = [
         %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+          percentiles: %{99 => 500.1}
         }},
         %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
+          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
+          percentiles: %{99 => 500.1}
         }}
       ]
 
@@ -118,10 +131,12 @@ defmodule Benchee.Formatters.ConsoleTest do
     test "can omit the comparisons" do
       scenarios = [
         %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+          percentiles: %{99 => 300.1}
         }},
         %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
+          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
+          percentiles: %{99 => 200.1}
         }}
       ]
 
@@ -141,10 +156,12 @@ defmodule Benchee.Formatters.ConsoleTest do
       second_name = String.duplicate("a", 40)
       scenarios = [
         %Scenario{job_name: second_name, run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+          percentiles: %{99 => 300.1}
         }},
         %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
+          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
+          percentiles: %{99 => 200.1}
         }}
       ]
 
@@ -159,7 +176,8 @@ defmodule Benchee.Formatters.ConsoleTest do
     test "doesn't create comparisons with only one benchmark run" do
       scenarios = [
         %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0
+          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
+          percentiles: %{99 => 200.1}
         }}
       ]
 
@@ -167,16 +185,26 @@ defmodule Benchee.Formatters.ConsoleTest do
       refute Regex.match? ~r/(Comparison|x slower)/, Enum.join([header, result])
     end
 
-    test "formats small averages and medians more precisely" do
+    test "formats small averages, medians, and percentiles more precisely" do
       scenarios = [
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 0.15, ips: 10_000.0, std_dev_ratio: 0.1, median: 0.0125
-        }}
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 0.15,
+            ips: 10_000.0,
+            std_dev_ratio: 0.1,
+            median: 0.0125,
+            percentiles: %{99 => 0.0234}
+
+          }
+        }
       ]
+
 
       assert [_, result] = Console.format_scenarios(scenarios, @console_config)
       assert Regex.match? ~r/0.150\s?μs/, result
       assert Regex.match? ~r/0.0125\s?μs/, result
+      assert Regex.match? ~r/0.0234\s?μs/, result
     end
 
     test "doesn't output weird 'e' formats" do
@@ -185,7 +213,8 @@ defmodule Benchee.Formatters.ConsoleTest do
           average: 11000.0,
           ips: 12000.0,
           std_dev_ratio: 13000.0,
-          median: 140000.0
+          median: 140000.0,
+          percentiles: %{99 => 200000.1}
         }}
       ]
 
@@ -196,6 +225,7 @@ defmodule Benchee.Formatters.ConsoleTest do
       assert result =~ "12 K"
       assert result =~ "13000"
       assert result =~ "140 ms"
+      assert result =~ "200.00 ms"
     end
   end
 
@@ -205,12 +235,14 @@ defmodule Benchee.Formatters.ConsoleTest do
       scenarios = [
         %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+            percentiles: %{99 => 400.1}
           }
         },
         %Scenario{job_name: "Job", input_name: "Other Arg", input: "Other Arg",
           run_time_statistics: %Statistics{
-            average: 400.0, ips: 2_500.0, std_dev_ratio: 0.15, median: 395.0
+            average: 400.0, ips: 2_500.0, std_dev_ratio: 0.15, median: 395.0,
+            percentiles: %{99 => 500.1}
           }
         }
       ]
@@ -221,34 +253,50 @@ defmodule Benchee.Formatters.ConsoleTest do
       [input_header, header, result] = my_arg
       assert input_header =~ "My Arg"
       assert header =~ @header_regex
-      assert result =~ ~r/Job.+5.+200.+10\.00%.+195\.5/
+      assert result =~ ~r/Job.+5.+200.+10\.00%.+195\.5.+400\.1/
 
       [input_header_2, header_2, result_2] = other_arg
       assert input_header_2 =~ "Other Arg"
       assert header_2 =~ @header_regex
-      assert result_2 =~ ~r/Job.+2\.5.+400.+15\.00%.+395/
+      assert result_2 =~ ~r/Job.+2\.5.+400.+15\.00%.+395.+500\.1/
     end
 
     test "with multiple inputs and two jobs" do
       scenarios = [
         %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1}
           }
         },
         %Scenario{job_name: "Other Job", input_name: "My Arg", input: "My Arg",
           run_time_statistics: %Statistics{
-            average: 100.0, ips: 10_000.0, std_dev_ratio: 0.3, median: 98.0
+            average: 100.0,
+            ips: 10_000.0,
+            std_dev_ratio: 0.3,
+            median: 98.0,
+            percentiles: %{99 => 200.1}
           }
         },
         %Scenario{job_name: "Job", input_name: "Other Arg", input: "Other Arg",
           run_time_statistics: %Statistics{
-            average: 400.0, ips: 2_500.0, std_dev_ratio: 0.15, median: 395.0
+            average: 400.0,
+            ips: 2_500.0,
+            std_dev_ratio: 0.15,
+            median: 395.0,
+            percentiles: %{99 => 500.1}
           }
         },
         %Scenario{job_name: "Other Job", input_name: "Other Arg", input: "Other Arg",
           run_time_statistics: %Statistics{
-            average: 250.0, ips: 4_000.0, std_dev_ratio: 0.31, median: 225.5
+            average: 250.0,
+            ips: 4_000.0,
+            std_dev_ratio: 0.31,
+            median: 225.5,
+            percentiles: %{99 => 300.1}
           }
         }
       ]
@@ -258,14 +306,14 @@ defmodule Benchee.Formatters.ConsoleTest do
 
       [input_header, _header, other_job, job, _comp, ref, slower] = my_arg
       assert input_header =~ "My Arg"
-      assert other_job =~ ~r/Other Job.+10.+100.+30\.00%.+98/
+      assert other_job =~ ~r/Other Job.+10.+100.+30\.00%.+98.+200\.1/
       assert job =~ ~r/Job.+5.+200.+10\.00%.+195\.5/
       ref =~ ~r/Other Job/
       slower =~ ~r/Job.+slower/
 
       [input_header_2, _, other_job_2, job_2, _, ref_2, slower_2] = other_arg
       assert input_header_2 =~ "Other Arg"
-      assert other_job_2 =~ ~r/Other Job.+4.+250.+31\.00%.+225\.5/
+      assert other_job_2 =~ ~r/Other Job.+4.+250.+31\.00%.+225\.5.+300\.1/
       assert job_2 =~ ~r/Job.+2\.5.+400.+15\.00%.+395/
       ref_2 =~ ~r/Other Job/
       slower_2 =~ ~r/Job.+slower/

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -14,16 +14,27 @@ defmodule Benchee.Formatters.ConsoleTest do
   describe ".output" do
     test "formats and prints the results right to the console" do
       scenarios = [
-        %Scenario{job_name: "Second", input_name: no_input(), input: no_input(),
+        %Scenario{
+          job_name: "Second",
+          input_name: no_input(),
+          input: no_input(),
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
             percentiles: %{99 => 400.1}
-
           }
         },
-        %Scenario{job_name: "First", input_name: no_input(), input: no_input(),
-           run_time_statistics: %Statistics{
-             average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
+        %Scenario{
+          job_name: "First",
+          input_name: no_input(),
+          input: no_input(),
+          run_time_statistics: %Statistics{
+             average: 100.0,
+             ips: 10_000.0,
+             std_dev_ratio: 0.1,
+             median: 90.0,
              percentiles: %{99 => 300.1}
            }
         }
@@ -47,18 +58,36 @@ defmodule Benchee.Formatters.ConsoleTest do
   describe ".format_scenarios" do
     test "sorts the the given stats fastest to slowest" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
-          percentiles: %{99 => 300.1}
-        }},
-        %Scenario{job_name: "Third", run_time_statistics: %Statistics{
-          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0,
-          percentiles: %{99 => 400.1}
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
-          percentiles: %{99 => 200.1}
-        }},
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1}
+          }
+        },
+        %Scenario{
+          job_name: "Third",
+          run_time_statistics: %Statistics{
+            average: 400.0,
+            ips: 2_500.0,
+            std_dev_ratio: 0.1,
+            median: 375.0,
+            percentiles: %{99 => 400.1}
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10_000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0,
+            percentiles: %{99 => 200.1}
+          }
+        },
       ]
 
       [_header, result_1, result_2, result_3 | _dont_care] =
@@ -71,14 +100,26 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     test "adjusts the label width to longest name" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 400.0, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0,
-          percentiles: %{99 => 400.1}
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
-          percentiles: %{99 => 300.1}
-        }}
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 400.0,
+            ips: 2_500.0,
+            std_dev_ratio: 0.1,
+            median: 375.0,
+            percentiles: %{99 => 400.1}
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1}
+          }
+        }
       ]
 
       expected_width = String.length "Second"
@@ -92,10 +133,15 @@ defmodule Benchee.Formatters.ConsoleTest do
       third_length = 40
       third_name = String.duplicate("a", third_length)
       long_scenario = %Scenario{
-        job_name: third_name, run_time_statistics: %Statistics{
-          average: 400.1, ips: 2_500.0, std_dev_ratio: 0.1, median: 375.0,
+        job_name: third_name,
+        run_time_statistics: %Statistics{
+          average: 400.1,
+          ips: 2_500.0,
+          std_dev_ratio: 0.1,
+          median: 375.0,
           percentiles: %{99 => 500.1}
-      }}
+        }
+      }
       longer_scenarios = scenarios ++ [long_scenario]
 
       # Include extra long name, expect width of 40 characters
@@ -110,14 +156,26 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     test "creates comparisons" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
-          percentiles: %{99 => 500.1}
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
-          percentiles: %{99 => 500.1}
-        }}
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 500.1}
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10_000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0,
+            percentiles: %{99 => 500.1}
+          }
+        }
       ]
 
       [_, _, _, comp_header, reference, slower] =
@@ -130,14 +188,26 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     test "can omit the comparisons" do
       scenarios = [
-        %Scenario{job_name: "Second", run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
-          percentiles: %{99 => 300.1}
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
-          percentiles: %{99 => 200.1}
-        }}
+        %Scenario{
+          job_name: "Second",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1}
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10_000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0,
+            percentiles: %{99 => 200.1}
+          }
+        }
       ]
 
       output =  Enum.join Console.format_scenarios(
@@ -155,14 +225,26 @@ defmodule Benchee.Formatters.ConsoleTest do
     test "adjusts the label width to longest name for comparisons" do
       second_name = String.duplicate("a", 40)
       scenarios = [
-        %Scenario{job_name: second_name, run_time_statistics: %Statistics{
-          average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
-          percentiles: %{99 => 300.1}
-        }},
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
-          percentiles: %{99 => 200.1}
-        }}
+        %Scenario{
+          job_name: second_name,
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1}
+          }
+        },
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10_000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0,
+            percentiles: %{99 => 200.1}
+          }
+        }
       ]
 
       expected_width = String.length(second_name)
@@ -175,10 +257,16 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     test "doesn't create comparisons with only one benchmark run" do
       scenarios = [
-        %Scenario{job_name: "First", run_time_statistics: %Statistics{
-          average: 100.0, ips: 10_000.0, std_dev_ratio: 0.1, median: 90.0,
-          percentiles: %{99 => 200.1}
-        }}
+        %Scenario{
+          job_name: "First",
+          run_time_statistics: %Statistics{
+            average: 100.0,
+            ips: 10_000.0,
+            std_dev_ratio: 0.1,
+            median: 90.0,
+            percentiles: %{99 => 200.1}
+          }
+        }
       ]
 
       assert [header, result] = Console.format_scenarios(scenarios, @console_config)
@@ -195,11 +283,9 @@ defmodule Benchee.Formatters.ConsoleTest do
             std_dev_ratio: 0.1,
             median: 0.0125,
             percentiles: %{99 => 0.0234}
-
           }
         }
       ]
-
 
       assert [_, result] = Console.format_scenarios(scenarios, @console_config)
       assert Regex.match? ~r/0.150\s?μs/, result
@@ -209,13 +295,16 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     test "doesn't output weird 'e' formats" do
       scenarios = [
-        %Scenario{job_name: "Job", run_time_statistics: %Statistics{
-          average: 11000.0,
-          ips: 12000.0,
-          std_dev_ratio: 13000.0,
-          median: 140000.0,
-          percentiles: %{99 => 200000.1}
-        }}
+        %Scenario{
+          job_name: "Job",
+          run_time_statistics: %Statistics{
+            average: 11000.0,
+            ips: 12000.0,
+            std_dev_ratio: 13000.0,
+            median: 140000.0,
+            percentiles: %{99 => 200000.1}
+          }
+        }
       ]
 
       assert [_, result] = Console.format_scenarios(scenarios, @console_config)
@@ -233,15 +322,27 @@ defmodule Benchee.Formatters.ConsoleTest do
     @header_regex ~r/Name.+ips.+average.+deviation.+median.+99th %.*/
     test "with multiple inputs and just one job" do
       scenarios = [
-        %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "My Arg",
+          input: "My Arg",
           run_time_statistics: %Statistics{
-            average: 200.0, ips: 5_000.0, std_dev_ratio: 0.1, median: 195.5,
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
             percentiles: %{99 => 400.1}
           }
         },
-        %Scenario{job_name: "Job", input_name: "Other Arg", input: "Other Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "Other Arg",
+          input: "Other Arg",
           run_time_statistics: %Statistics{
-            average: 400.0, ips: 2_500.0, std_dev_ratio: 0.15, median: 395.0,
+            average: 400.0,
+            ips: 2_500.0,
+            std_dev_ratio: 0.15,
+            median: 395.0,
             percentiles: %{99 => 500.1}
           }
         }
@@ -263,7 +364,10 @@ defmodule Benchee.Formatters.ConsoleTest do
 
     test "with multiple inputs and two jobs" do
       scenarios = [
-        %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "My Arg",
+          input: "My Arg",
           run_time_statistics: %Statistics{
             average: 200.0,
             ips: 5_000.0,
@@ -272,7 +376,10 @@ defmodule Benchee.Formatters.ConsoleTest do
             percentiles: %{99 => 300.1}
           }
         },
-        %Scenario{job_name: "Other Job", input_name: "My Arg", input: "My Arg",
+        %Scenario{
+          job_name: "Other Job",
+          input_name: "My Arg",
+          input: "My Arg",
           run_time_statistics: %Statistics{
             average: 100.0,
             ips: 10_000.0,
@@ -281,7 +388,10 @@ defmodule Benchee.Formatters.ConsoleTest do
             percentiles: %{99 => 200.1}
           }
         },
-        %Scenario{job_name: "Job", input_name: "Other Arg", input: "Other Arg",
+        %Scenario{
+          job_name: "Job",
+          input_name: "Other Arg",
+          input: "Other Arg",
           run_time_statistics: %Statistics{
             average: 400.0,
             ips: 2_500.0,
@@ -290,7 +400,10 @@ defmodule Benchee.Formatters.ConsoleTest do
             percentiles: %{99 => 500.1}
           }
         },
-        %Scenario{job_name: "Other Job", input_name: "Other Arg", input: "Other Arg",
+        %Scenario{
+          job_name: "Other Job",
+          input_name: "Other Arg",
+          input: "Other Arg",
           run_time_statistics: %Statistics{
             average: 250.0,
             ips: 4_000.0,

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -200,7 +200,7 @@ defmodule Benchee.Formatters.ConsoleTest do
   end
 
   describe ".format" do
-    @header_regex ~r/Name.+ips.+average.+deviation.+median.*/
+    @header_regex ~r/Name.+ips.+average.+deviation.+median.+P99.*/
     test "with multiple inputs and just one job" do
       scenarios = [
         %Scenario{job_name: "Job", input_name: "My Arg", input: "My Arg",

--- a/test/benchee/statistics/percentile_test.exs
+++ b/test/benchee/statistics/percentile_test.exs
@@ -21,7 +21,7 @@ defmodule Benchee.Statistics.PercentileTest do
   # Test data from:
   #   http://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm
   test "90th percentile" do
-    result = Percentile.percentile(@nist_sample_data, 90)
+    %{90 => result} = Percentile.percentiles(@nist_sample_data, 90)
     assert Float.round(result, 4) == 95.1981
   end
 end

--- a/test/benchee/statistics/percentile_test.exs
+++ b/test/benchee/statistics/percentile_test.exs
@@ -31,54 +31,54 @@ defmodule Benchee.Statistics.PercentileTest do
 
   describe "a list of one element" do
     setup do
-      {:ok, samples: [100]}
+      {:ok, samples: [300]}
     end
 
     test "1st percentile", %{samples: samples} do
       %{1 => result} = Percentile.percentiles(samples, [1])
-      assert result == 100.0
+      assert result == 300.0
     end
 
     test "50th percentile", %{samples: samples} do
       %{50 => result} = Percentile.percentiles(samples, [50])
-      assert result == 100.0
+      assert result == 300.0
     end
 
     test "99th percentile", %{samples: samples} do
       %{99 => result} = Percentile.percentiles(samples, [99])
-      assert result == 100.0
+      assert result == 300.0
     end
   end
 
   describe "a list of two elements" do
     setup do
-      {:ok, samples: [100, 200]}
+      {:ok, samples: [300, 200]}
     end
 
     test "1st percentile", %{samples: samples} do
       %{1 => result} = Percentile.percentiles(samples, [1])
-      assert result == 100.0
+      assert result == 203.0
     end
 
     test "50th percentile", %{samples: samples} do
       %{50 => result} = Percentile.percentiles(samples, [50])
-      assert result == 150.0
+      assert result == 250.0
     end
 
     test "99th percentile", %{samples: samples} do
       %{99 => result} = Percentile.percentiles(samples, [99])
-      assert result == 200.0
+      assert result == 300.0
     end
   end
 
   describe "a list of three elements" do
     setup do
-      {:ok, samples: [100, 200, 300]}
+      {:ok, samples: [100, 300, 200]}
     end
 
     test "1st percentile", %{samples: samples} do
       %{1 => result} = Percentile.percentiles(samples, [1])
-      assert result == 100.0
+      assert result == 104.0
     end
 
     test "50th percentile", %{samples: samples} do

--- a/test/benchee/statistics/percentile_test.exs
+++ b/test/benchee/statistics/percentile_test.exs
@@ -18,7 +18,8 @@ defmodule Benchee.Statistics.PercentileTest do
     95.1682
   ]
 
-  @tag run: true
+  # Test data from:
+  #   http://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm
   test "90th percentile" do
     result = Percentile.percentile(@nist_sample_data, 90)
     assert Float.round(result, 4) == 95.1981

--- a/test/benchee/statistics/percentile_test.exs
+++ b/test/benchee/statistics/percentile_test.exs
@@ -24,4 +24,71 @@ defmodule Benchee.Statistics.PercentileTest do
     %{90 => result} = Percentile.percentiles(@nist_sample_data, 90)
     assert Float.round(result, 4) == 95.1981
   end
+
+  test "an empty list raises an argument error" do
+    assert_raise ArgumentError, fn -> Percentile.percentiles([], [1]) end
+  end
+
+  describe "a list of one element" do
+    setup do
+      {:ok, samples: [100]}
+    end
+
+    test "1st percentile", %{samples: samples} do
+      %{1 => result} = Percentile.percentiles(samples, [1])
+      assert result == 100.0
+    end
+
+    test "50th percentile", %{samples: samples} do
+      %{50 => result} = Percentile.percentiles(samples, [50])
+      assert result == 100.0
+    end
+
+    test "99th percentile", %{samples: samples} do
+      %{99 => result} = Percentile.percentiles(samples, [99])
+      assert result == 100.0
+    end
+  end
+
+  describe "a list of two elements" do
+    setup do
+      {:ok, samples: [100, 200]}
+    end
+
+    test "1st percentile", %{samples: samples} do
+      %{1 => result} = Percentile.percentiles(samples, [1])
+      assert result == 100.0
+    end
+
+    test "50th percentile", %{samples: samples} do
+      %{50 => result} = Percentile.percentiles(samples, [50])
+      assert result == 150.0
+    end
+
+    test "99th percentile", %{samples: samples} do
+      %{99 => result} = Percentile.percentiles(samples, [99])
+      assert result == 200.0
+    end
+  end
+
+  describe "a list of three elements" do
+    setup do
+      {:ok, samples: [100, 200, 300]}
+    end
+
+    test "1st percentile", %{samples: samples} do
+      %{1 => result} = Percentile.percentiles(samples, [1])
+      assert result == 100.0
+    end
+
+    test "50th percentile", %{samples: samples} do
+      %{50 => result} = Percentile.percentiles(samples, [50])
+      assert result == 200.0
+    end
+
+    test "99th percentile", %{samples: samples} do
+      %{99 => result} = Percentile.percentiles(samples, [99])
+      assert result == 300.0
+    end
+  end
 end

--- a/test/benchee/statistics/percentile_test.exs
+++ b/test/benchee/statistics/percentile_test.exs
@@ -1,0 +1,26 @@
+defmodule Benchee.Statistics.PercentileTest do
+  use ExUnit.Case, async: true
+  alias Benchee.Statistics.Percentile
+  doctest Percentile
+
+  @nist_sample_data [
+    95.1772,
+    95.1567,
+    95.1937,
+    95.1959,
+    95.1442,
+    95.0610,
+    95.1591,
+    95.1195,
+    95.1065,
+    95.0925,
+    95.1990,
+    95.1682
+  ]
+
+  @tag run: true
+  test "90th percentile" do
+    result = Percentile.percentile(@nist_sample_data, 90)
+    assert Float.round(result, 4) == 95.1981
+  end
+end

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -4,7 +4,7 @@ defmodule BencheeTest do
   import Benchee.TestHelpers
   doctest Benchee
 
-  @header_regex ~r/^Name.+ips.+average.+deviation.+median$/m
+  @header_regex ~r/^Name.+ips.+average.+deviation.+median.+P99$/m
   @test_times   [time: 0.01, warmup: 0.005]
   test "integration step by step" do
     capture_io fn ->

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -4,7 +4,7 @@ defmodule BencheeTest do
   import Benchee.TestHelpers
   doctest Benchee
 
-  @header_regex ~r/^Name.+ips.+average.+deviation.+median.+P99$/m
+  @header_regex ~r/^Name.+ips.+average.+deviation.+median.+99th %$/m
   @test_times   [time: 0.01, warmup: 0.005]
   test "integration step by step" do
     capture_io fn ->


### PR DESCRIPTION
Hi all,

Here's a first pass at adding nth percentile calculations for initial review (see #48). Essentially just:

- a percentile function with tests (calculates any percentile value)
- replacing the current median function with the new percentile function (since the median `is` the 50th percentile value)

There are lots of methods for calculating percentile, and I don't know much about the theory. Of the three most accepted, I chose the one that was explained in greatest detail. I left some resources in a comment for further reading, but I feel confident this method is suitable for our purposes, but it would be trivial to replace, or even offer alternate strategies.

This implementation has similar big-O complexity to the current median function (sorting and then traversing the list of samples), although it does remove one list traversal.

Questions:

- Should percentile be included by default, or enabled with an option?

- The issue suggests that we should only offer the 99th percentile. That seems like a reasonable default, although I suspect that folks will have widely varying ideas about what percentile value they are interested in, and it probably depends on their data. Do we want to offer more flexible configuration for percentile? There's nothing to do differently, calculation-wise, only figuring out a good user experience. Could also be added later.

Left to do:

- [ ] add percentile value(s) to results
- [ ] update output tests

