### PR TITLE
before_each gets inputs and passes them on

### DIFF
--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -30,75 +30,6 @@ defmodule Benchee.Benchmark.Runner do
     end)
   end
 
-  defp update_num_iterations(scenario_context, scenario, num_iterations) do
-    # every update of the number iterations could mean we need a different
-    # benchmarking function (as we go from 1 to n iterations)
-    %ScenarioContext{scenario_context | num_iterations: num_iterations}
-    |> update_benchmarking_function(scenario)
-  end
-
-  defp update_benchmarking_function(scenario_context, scenario) do
-    %ScenarioContext{scenario_context |
-      benchmarking_function:
-        build_benchmarking_function(scenario, scenario_context)
-    }
-  end
-
-  # Builds the appropriate function to benchmark. Takes into account the
-  # combinations of the following cases:
-  #
-  # * an input is specified - creates a 0-argument function calling the original
-  #   function with that input
-  # * number of iterations - when there's more than one iteration we repeat the
-  #   benchmarking function during execution and measure the the total run time.
-  #   We only run multiple iterations if a function is so fast that we can't
-  #   accurately measure it in one go. Hence, we can't split up the function
-  #   execution and hooks anymore and sadly we also measure the time of the
-  #   hooks.
-  defp build_benchmarking_function(
-      %Scenario{function: function},
-      %ScenarioContext{num_iterations: 1, scenario_input: input}) do
-    main_function(function, input)
-  end
-  defp build_benchmarking_function(
-        %Scenario{
-          function: function, before_each: nil, after_each: nil
-        },
-        %ScenarioContext{
-          num_iterations: iterations,
-          scenario_input: input,
-          config: %{after_each: nil, before_each: nil}
-        })
-        when iterations > 1 do
-    main = main_function(function, input)
-    # with no before/after each we can safely omit them and don't get the hit
-    # on run time measurements (See PR discussions for this for more info #127)
-    fn -> RepeatN.repeat_n(main, iterations) end
-  end
-  defp build_benchmarking_function(
-        scenario = %Scenario{function: function},
-        scenario_context = %ScenarioContext{
-          num_iterations: iterations,
-          scenario_input: input
-        })
-        when iterations > 1 do
-    main = main_function(function, input)
-    fn ->
-      RepeatN.repeat_n(
-        fn ->
-          run_before_each(scenario, scenario_context)
-          return_value = main.()
-          run_after_each(return_value, scenario, scenario_context)
-        end,
-        iterations
-      )
-    end
-  end
-
-  @no_input Benchmark.no_input()
-  defp main_function(function, @no_input), do: function
-  defp main_function(function, input),     do: fn -> function.(input) end
-
   defp parallel_benchmark(
          scenario = %Scenario{job_name: job_name, input_name: input_name},
          scenario_context = %ScenarioContext{
@@ -116,8 +47,6 @@ defmodule Benchee.Benchmark.Runner do
     scenario_input = run_before_scenario(scenario, scenario_context)
     scenario_context =
       %ScenarioContext{scenario_context | scenario_input: scenario_input}
-    scenario_context =
-      update_benchmarking_function(scenario_context, scenario)
     _ = run_warmup(scenario, scenario_context)
     measurements = run_benchmark(scenario, scenario_context)
     run_after_scenario(scenario, scenario_context)
@@ -132,11 +61,11 @@ defmodule Benchee.Benchmark.Runner do
                              config: %{before_scenario: global_before_scenario}
                            }) do
     input
-    |> run_before_scenario_function(global_before_scenario)
-    |> run_before_scenario_function(local_before_scenario)
+    |> run_before_function(global_before_scenario)
+    |> run_before_function(local_before_scenario)
   end
 
-  defp run_before_scenario_function(input, function) do
+  defp run_before_function(input, function) do
     if function do
       function.(input)
     else
@@ -177,9 +106,11 @@ defmodule Benchee.Benchmark.Runner do
     {num_iterations, initial_run_time} =
       determine_n_times(scenario, scenario_context, fast_warning)
     new_context =
-      %ScenarioContext{scenario_context | current_time: current_time(),
-                                          end_time: end_time}
-      |> update_num_iterations(scenario, num_iterations)
+      %ScenarioContext{scenario_context | 
+        current_time: current_time(),
+        end_time: end_time,
+        num_iterations: num_iterations
+      }
 
     updated_scenario = %Scenario{scenario | run_times: [initial_run_time]}
     do_benchmark(updated_scenario, new_context)
@@ -203,9 +134,9 @@ defmodule Benchee.Benchmark.Runner do
       {num_iterations, run_time / num_iterations}
     else
       if fast_warning, do: printer.fast_warning()
-      new_context = update_num_iterations(scenario_context,
-                                          scenario,
-                                          num_iterations * @times_multiplier)
+      new_context = %ScenarioContext{scenario_context |
+        num_iterations: num_iterations * @times_multiplier
+      }
       determine_n_times(scenario, new_context, false)
     end
   end
@@ -232,34 +163,83 @@ defmodule Benchee.Benchmark.Runner do
     measure_iteration(scenario, scenario_context) / num_iterations
   end
 
-  defp measure_iteration(scenario, scenario_context = %ScenarioContext{
-                                     num_iterations: 1,
-                                     benchmarking_function: function
-                                   }) do
-    run_before_each(scenario, scenario_context)
-    {microseconds, return_value} = :timer.tc function
+  defp measure_iteration(scenario = %Scenario{function: function},
+                         scenario_context = %ScenarioContext{
+                           num_iterations: 1
+                         }) do
+    new_input = run_before_each(scenario, scenario_context)
+    {microseconds, return_value} = :timer.tc main_function(function, new_input)
     run_after_each(return_value, scenario, scenario_context)
     microseconds
   end
-  defp measure_iteration(_scenario, %ScenarioContext{
+  defp measure_iteration(scenario, scenario_context = %ScenarioContext{
                           num_iterations: iterations,
-                          benchmarking_function: function
                         }) when iterations > 1 do
     # When we have more than one iteration, then the repetition and calling
     # of hooks is already included in the function, for reference/reasoning see
     # `build_benchmarking_function/2`
+    function = build_benchmarking_function(scenario, scenario_context)
     {microseconds, _return_value} = :timer.tc function
     microseconds
+  end
+
+  @no_input Benchmark.no_input()
+  defp main_function(function, @no_input), do: function
+  defp main_function(function, input),     do: fn -> function.(input) end
+
+  # Builds the appropriate function to benchmark. Takes into account the
+  # combinations of the following cases:
+  #
+  # * an input is specified - creates a 0-argument function calling the original
+  #   function with that input
+  # * number of iterations - when there's more than one iteration we repeat the
+  #   benchmarking function during execution and measure the the total run time.
+  #   We only run multiple iterations if a function is so fast that we can't
+  #   accurately measure it in one go. Hence, we can't split up the function
+  #   execution and hooks anymore and sadly we also measure the time of the
+  #   hooks.
+  defp build_benchmarking_function(
+         %Scenario{
+           function: function, before_each: nil, after_each: nil
+         },
+         %ScenarioContext{
+           num_iterations: iterations,
+           scenario_input: input,
+           config: %{after_each: nil, before_each: nil}
+         })
+         when iterations > 1 do
+    main = main_function(function, input)
+    # with no before/after each we can safely omit them and don't get the hit
+    # on run time measurements (See PR discussions for this for more info #127)
+    fn -> RepeatN.repeat_n(main, iterations) end
+  end
+  defp build_benchmarking_function(
+         scenario = %Scenario{function: function},
+         scenario_context = %ScenarioContext{num_iterations: iterations})
+         when iterations > 1 do
+    fn ->
+      RepeatN.repeat_n(
+        fn ->
+          new_input = run_before_each(scenario, scenario_context)
+          main = main_function(function, new_input)
+          return_value = main.()
+          run_after_each(return_value, scenario, scenario_context)
+        end,
+        iterations
+      )
+    end
   end
 
   defp run_before_each(%{
                          before_each: local_before_each
                        },
                        %{
-                         config: %{before_each: global_before_each}
+                         config: %{before_each: global_before_each},
+                         scenario_input: input
                        }) do
-    if global_before_each, do: global_before_each.()
-    if local_before_each,  do: local_before_each.()
+    input
+    |> run_before_function(global_before_each)
+    |> run_before_function(local_before_each)
   end
 
   defp run_after_each(return_value,

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -106,7 +106,7 @@ defmodule Benchee.Benchmark.Runner do
     {num_iterations, initial_run_time} =
       determine_n_times(scenario, scenario_context, fast_warning)
     new_context =
-      %ScenarioContext{scenario_context | 
+      %ScenarioContext{scenario_context |
         current_time: current_time(),
         end_time: end_time,
         num_iterations: num_iterations

--- a/lib/benchee/benchmark/scenario_context.ex
+++ b/lib/benchee/benchmark/scenario_context.ex
@@ -7,7 +7,6 @@ defmodule Benchee.Benchmark.ScenarioContext do
     :printer,
     :current_time,
     :end_time,
-    :benchmarking_function,
     :scenario_input, # before_scenario can alter the original input
     num_iterations: 1
   ]
@@ -17,7 +16,6 @@ defmodule Benchee.Benchmark.ScenarioContext do
     printer:               module,
     current_time:          pos_integer | nil,
     end_time:              pos_integer | nil,
-    benchmarking_function: (() -> any) | nil,
     scenario_input:        any,
     num_iterations:        pos_integer
   }

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -250,7 +250,7 @@ defmodule Benchee.Benchmark.RunnerTest do
         configuration: %{
           warmup: 0,
           time: 100,
-          before_each: fn -> send(me, :before) end,
+          before_each: fn(input) -> send(me, :before); input end,
           after_each: fn(_) -> send(me, :after) end
         }
       }
@@ -272,7 +272,7 @@ defmodule Benchee.Benchmark.RunnerTest do
       |> test_suite
       |> Benchmark.benchmark("job", {
            fn -> :timer.sleep 1 end,
-           before_each: fn -> send(me, :before) end,
+           before_each: fn(input) -> send(me, :before); input end,
            after_each: fn(_) -> send(me, :after) end,
            before_scenario: fn(input) -> send(me, :before_scenario); input end,
            after_scenario: fn -> send(me, :after_scenario) end})
@@ -294,7 +294,7 @@ defmodule Benchee.Benchmark.RunnerTest do
       |> test_suite
       |> Benchmark.benchmark("job", {
            fn -> :timer.sleep 1 end,
-           before_each: fn -> send(me, :before) end,
+           before_each: fn(input) -> send(me, :before); input end,
            after_each: fn(_) -> send(me, :after) end,
            before_scenario: fn(input) -> send(me, :before_scenario); input end,
            after_scenario: fn -> send(me, :after_scenario) end})
@@ -311,7 +311,7 @@ defmodule Benchee.Benchmark.RunnerTest do
         configuration: %{
           warmup: 0,
           time: 100,
-          before_each: fn -> send me, :global_before end,
+          before_each: fn(input) -> send(me, :global_before); input end,
           after_each:  fn(_) -> send me, :global_after end,
           before_scenario: fn(input) ->
             send(me, :global_before_scenario)
@@ -324,7 +324,7 @@ defmodule Benchee.Benchmark.RunnerTest do
       |> test_suite
       |> Benchmark.benchmark("job", {
            fn(_) -> :timer.sleep 1 end,
-           before_each: fn -> send(me, :local_before) end,
+           before_each: fn(input) -> send(me, :local_before); input end,
            after_each: fn(_) -> send(me, :local_after) end,
            before_scenario: fn(input) ->
              send(me, :local_before_scenario)
@@ -347,7 +347,7 @@ defmodule Benchee.Benchmark.RunnerTest do
         configuration: %{
           warmup: 0,
           time: 100,
-          before_each: fn -> send me, :global_before end,
+          before_each: fn(input) -> send(me, :global_before); input end,
           after_each:  fn(_) -> send me, :global_after end,
           after_scenario: fn -> send me, :global_after_scenario end
         }
@@ -355,7 +355,7 @@ defmodule Benchee.Benchmark.RunnerTest do
       |> test_suite
       |> Benchmark.benchmark("job", {
            fn -> :timer.sleep 1 end,
-           before_each: fn -> send me, :local_1_before end,
+           before_each: fn(input) -> send(me, :local_1_before); input end,
            before_scenario: fn(input) ->
              send me, :local_scenario_before
              input
@@ -376,14 +376,14 @@ defmodule Benchee.Benchmark.RunnerTest do
         configuration: %{
           warmup: 0,
           time: 100,
-          before_each: fn -> send me, :global_before end,
+          before_each: fn(input) -> send(me, :global_before); input end,
           after_each:  fn(_) -> send me, :global_after end
         }
       }
       |> test_suite
       |> Benchmark.benchmark("job", {
            fn -> :timer.sleep 1 end,
-           before_each: fn -> send me, :local_before end,
+           before_each: fn(input) -> send(me, :local_before); input end,
            after_each:  fn(_) -> send me, :local_after end,
            before_scenario: fn(input) ->
              send me, :local_before_scenario
@@ -391,7 +391,7 @@ defmodule Benchee.Benchmark.RunnerTest do
            end})
       |> Benchmark.benchmark("job 2", {
            fn -> :timer.sleep 1 end,
-           before_each: fn -> send me, :local_2_before end,
+           before_each: fn(input) -> send(me, :local_2_before); input end,
            after_each:  fn(_) -> send me, :local_2_after end,
            after_scenario: fn -> send me, :local_2_after_scenario end})
       |> Benchmark.measure(TestPrinter)
@@ -410,7 +410,7 @@ defmodule Benchee.Benchmark.RunnerTest do
                 configuration: %{
                   warmup: 0,
                   time: 10_000,
-                  before_each: fn -> send me, :global_before end,
+                  before_each: fn(input) -> send(me, :global_before); input end,
                   after_each:  fn(_) -> send me, :global_after end,
                   before_scenario: fn(input) ->
                     send me, :global_before_scenario
@@ -424,7 +424,7 @@ defmodule Benchee.Benchmark.RunnerTest do
         |> test_suite
         |> Benchmark.benchmark("job", {
              fn -> :timer.sleep 1 end,
-             before_each: fn -> send me, :local_before end,
+             before_each: fn(input) -> send(me, :local_before); input end,
              after_each:  fn(_) -> send me, :local_after end,
              before_scenario: fn(input) ->
                send(me, :local_before_scenario)
@@ -476,9 +476,9 @@ defmodule Benchee.Benchmark.RunnerTest do
       me = self()
       suite = %Suite{
                 configuration: %{
-                  warmup: 0,
+                  warmup: 1,
                   time: 1_000,
-                  before_each: fn -> send me, :global_before end,
+                  before_each: fn(input) -> send(me, :global_before); input end,
                   after_each:  fn(_) -> send me, :global_after end
                 }
               }
@@ -486,8 +486,8 @@ defmodule Benchee.Benchmark.RunnerTest do
         suite
         |> test_suite
         |> Benchmark.benchmark("job", {fn -> 0 end,
-                               before_each: fn -> send me, :local_before end,
-                               after_each:  fn(_) -> send me, :local_after end})
+             before_each: fn(input) -> send(me, :local_before); input end,
+             after_each:  fn(_) -> send me, :local_after end})
         |> Benchmark.measure(TestPrinter)
 
       {:messages, messages} = Process.info self(), :messages
@@ -563,14 +563,18 @@ defmodule Benchee.Benchmark.RunnerTest do
       assert_received {:local, :value}
     end
 
-    test "before_scenario is passed the input and can adapt it to pass it on" do 
+    test "before_* is passed the input and can adapt it to pass it on" do 
       me = self()
       %Suite{
         configuration: %{
           warmup: 1,
           time: 1,
           before_scenario: fn(input) ->
-            send(me, {:global, input})
+            send(me, {:global_scenario, input})
+            input + 1
+          end,
+          before_each: fn(input) ->
+            send(me, {:global_each, input})
             input + 1
           end,
           inputs: %{"basic input" => 0}
@@ -583,24 +587,34 @@ defmodule Benchee.Benchmark.RunnerTest do
            send(me, {:runner, input})
          end,
          before_scenario: fn(input) ->
-           send(me, {:local, input})
+           send(me, {:local_scenario, input})
            input + 1
-         end})
+         end,
+         before_each: fn(input) ->
+          send(me, {:local_each, input})
+          input + 1
+        end})
       |> Benchmark.measure(TestPrinter)
 
       assert_received_exactly [
-        {:global, 0}, {:local, 1}, {:runner, 2}, {:runner, 2}
+        {:global_scenario, 0}, {:local_scenario, 1},
+        {:global_each, 2}, {:local_each, 3}, {:runner, 4},
+        {:global_each, 2}, {:local_each, 3}, {:runner, 4}
       ]
     end
 
-    test "before_scenario still works when there is no input given" do 
+    test "before_* still works when there is no input given" do 
       me = self()
       %Suite{
         configuration: %{
           warmup: 1,
           time: 1,
           before_scenario: fn(input) ->
-            send(me, {:global, input})
+            send(me, {:global_scenario, input})
+            input
+          end,
+          before_each: fn(input) ->
+            send(me, {:global_each, input})
             input
           end
         }
@@ -611,13 +625,21 @@ defmodule Benchee.Benchmark.RunnerTest do
            :timer.sleep 1
          end,
          before_scenario: fn(input) ->
-           send(me, {:local, input})
+           send(me, {:local_scenario, input})
+           input
+         end,
+         before_each: fn(input) ->
+           send(me, {:local_each, input})
            input
          end})
       |> Benchmark.measure(TestPrinter)
 
+      no_input = Benchmark.no_input()
+
       assert_received_exactly [
-        {:global, Benchmark.no_input()}, {:local, Benchmark.no_input()}
+        {:global_scenario, no_input}, {:local_scenario, no_input},
+        {:global_each, no_input}, {:local_each, no_input},
+        {:global_each, no_input}, {:local_each, no_input}
       ]
     end
 

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -330,7 +330,7 @@ defmodule BencheeTest do
         Benchee.run %{
           "sleeper"   => {
             fn -> :timer.sleep 1 end,
-            before_each: fn -> send myself, :local_before end,
+            before_each: fn(input) -> send(myself, :local_before); input end,
             after_each:  fn(_) -> send myself, :local_after end,
             before_scenario: fn(input) ->
               send myself, :local_before_scenario
@@ -340,7 +340,7 @@ defmodule BencheeTest do
           "sleeper 2" => fn -> :timer.sleep 1 end
         }, time: 0.0001,
            warmup: 0,
-           before_each: fn -> send myself, :global_before end,
+           before_each: fn(input) -> send(myself, :global_before); input end,
            after_each:  fn(_) -> send myself, :global_after end,
            before_scenario: fn(input) ->
              send myself, :global_before_scenario


### PR DESCRIPTION
Sadly, this breaks our new found great achievement that we have
a benchmarking function that we can reuse. The reason being, that
when before_each can change the input for every invocation - so
the function we create has to be recreated every time.

This could potentially be optimized further, by using `:timer.tc/2`
or be determining if before_* methods are given at all. Plus for
our "repeat n" case, the function could be reused and doesn't have
to be recreated everytime.