### PR TITLE
Provide .tool-versions with current go do elixir/erlang versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@
 erl_crash.dump
 *.ez
 elixir_build_*
-.tool-versions
 doc
 docs

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.5.2
+erlang 20.0


### PR DESCRIPTION
Interested to see how people feel about this.

a) Not everyone uses asdf so not directly affected
b) if you know where to look (travis) you already have a place to
get an overview of supported versions. Should also be in the
README but is probably missing atm ;P
c) potentially high churn (ideally it'll be updated rather quickly
for every new elixr/erlang release)

So, does it provide value - yay or nay?