### PR TITLE
after_scenario with inputs implementation

### DIFF
--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -92,10 +92,11 @@ defmodule Benchee.Benchmark.Runner do
                             after_scenario: local_after_scenario
                           },
                           %{
-                            config: %{after_scenario: global_after_scenario}
+                            config: %{after_scenario: global_after_scenario},
+                            scenario_input: input
                           }) do
-    if local_after_scenario,  do: local_after_scenario.()
-    if global_after_scenario, do: global_after_scenario.()
+    if local_after_scenario,  do: local_after_scenario.(input)
+    if global_after_scenario, do: global_after_scenario.(input)
   end
 
   defp measure_runtimes(scenario, context, run_time, fast_warning)

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -336,17 +336,17 @@ defmodule BencheeTest do
               send myself, :local_before_scenario
               input
             end,
-            after_scenario: fn -> send myself, :local_after_scenario end},
+            after_scenario: fn(_) -> send myself, :local_after_scenario end},
           "sleeper 2" => fn -> :timer.sleep 1 end
         }, time: 0.0001,
            warmup: 0,
            before_each: fn(input) -> send(myself, :global_before); input end,
-           after_each:  fn(_) -> send myself, :global_after end,
+           after_each: fn(_) -> send myself, :global_after end,
            before_scenario: fn(input) ->
              send myself, :global_before_scenario
              input
            end,
-           after_scenario:  fn -> send myself, :global_after_scenario end
+           after_scenario: fn(_) -> send myself, :global_after_scenario end
       end
 
       assert_received_exactly [


### PR DESCRIPTION
Pondered whether after_scenario should behave like before_* i.e.
the input can be altered and passed on. Didn't see much sense
in that though as the last value (global_after_scenario) will go
nowher and the values aren't passed to any benchmarking function.

Also for consistency with `after_each` I decided to just pass them
the output of the last before_scenario (just like all after_each's
just get the return value of the benchmarking function).