### PR TITLE
Convert for all

### DIFF
--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -76,11 +76,25 @@ defmodule Benchee.Conversion.Count do
   end
 
   @doc """
-  Get a unit by its atom representation.
+  Get a unit by its atom representation. If handed already a %Unit{} struct it
+  just returns it.
 
   ## Examples
 
       iex> Benchee.Conversion.Count.unit_for :thousand
+      %Benchee.Conversion.Unit{
+        name:      :thousand,
+        magnitude: 1_000,
+        label:     "K",
+        long:      "Thousand"
+      }
+
+      iex> Benchee.Conversion.Count.unit_for(%Benchee.Conversion.Unit{
+      ...>   name:      :thousand,
+      ...>   magnitude: 1_000,
+      ...>   label:     "K",
+      ...>   long:      "Thousand"
+      ...>})
       %Benchee.Conversion.Unit{
         name:      :thousand,
         magnitude: 1_000,

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -115,6 +115,21 @@ defmodule Benchee.Conversion.Count do
   end
 
   @doc """
+  Converts a value for a specified %Unit or unit atom and converts it to the equivalent of another unit of measure.
+
+  ## Examples
+
+    iex> {value, unit} = Benchee.Conversion.Count.convert({2500, :thousand}, :million)
+    iex> value
+    2.5
+    iex> unit.name
+    :million
+  """
+  def convert(number_and_unit, desired_unit) do
+    Scale.convert number_and_unit, desired_unit, __MODULE__
+  end
+
+  @doc """
   Finds the best unit for a list of counts. By default, chooses the most common
   unit. In case of tie, chooses the largest of the most common units.
 

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -131,6 +131,21 @@ defmodule Benchee.Conversion.Duration do
   end
 
   @doc """
+  Converts a value for a specified %Unit or unit atom and converts it to the equivalent of another unit of measure.
+
+  ## Examples
+
+    iex> {value, unit} = Benchee.Conversion.Duration.convert({90, :minute}, :hour)
+    iex> value
+    1.5
+    iex> unit.name
+    :hour
+  """
+  def convert(number_and_unit, desired_unit) do
+    Scale.convert number_and_unit, desired_unit, __MODULE__
+  end
+
+  @doc """
   Converts a value of the given unit into microseconds
 
   ## Examples

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -95,11 +95,25 @@ defmodule Benchee.Conversion.Duration do
   end
 
   @doc """
-  Get a unit by its atom representation.
+  Get a unit by its atom representation. If handed already a %Unit{} struct it
+  just returns it.
 
   ## Examples
 
       iex> Benchee.Conversion.Duration.unit_for :hour
+      %Benchee.Conversion.Unit{
+        name:      :hour,
+        magnitude: 3_600_000_000,
+        label:     "h",
+        long:      "Hours"
+      }
+
+      iex> Benchee.Conversion.Duration.unit_for(%Benchee.Conversion.Unit{
+      ...>   name:      :hour,
+      ...>   magnitude: 3_600_000_000,
+      ...>   label:     "h",
+      ...>   long:      "Hours"
+      ...>})
       %Benchee.Conversion.Unit{
         name:      :hour,
         magnitude: 3_600_000_000,

--- a/lib/benchee/conversion/memory.ex
+++ b/lib/benchee/conversion/memory.ex
@@ -118,11 +118,25 @@ defmodule Benchee.Conversion.Memory do
   end
 
   @doc """
-  Get a unit by its atom representation.
+  Get a unit by its atom representation. If handed already a %Unit{} struct it
+  just returns it.
 
   ## Examples
 
       iex> Benchee.Conversion.Memory.unit_for :gigabyte
+      %Benchee.Conversion.Unit{
+          name:      :gigabyte,
+          magnitude: 1_073_741_824,
+          label:     "GB",
+          long:      "Gigabytes"
+      }
+
+      iex> Benchee.Conversion.Memory.unit_for(%Benchee.Conversion.Unit{
+      ...>   name:      :gigabyte,
+      ...>   magnitude: 1_073_741_824,
+      ...>   label:     "GB",
+      ...>   long:      "Gigabytes"
+      ...>})
       %Benchee.Conversion.Unit{
           name:      :gigabyte,
           magnitude: 1_073_741_824,

--- a/lib/benchee/conversion/memory.ex
+++ b/lib/benchee/conversion/memory.ex
@@ -59,6 +59,13 @@ defmodule Benchee.Conversion.Memory do
     1.0
     iex> unit.name
     :megabyte
+
+    iex> current_unit = Benchee.Conversion.Memory.unit_for :kilobyte
+    iex> {value, unit} = Benchee.Conversion.Memory.convert({1024, current_unit}, :megabyte)
+    iex> value
+    1.0
+    iex> unit.name
+    :megabyte
   """
   @spec convert({number, any_unit}, any_unit) :: Scale.scaled_number
   def convert(number_and_unit, desired_unit) do

--- a/lib/benchee/conversion/memory.ex
+++ b/lib/benchee/conversion/memory.ex
@@ -46,11 +46,8 @@ defmodule Benchee.Conversion.Memory do
               }
   }
 
-  # Unit conversion functions
-
   @type unit_atom :: :byte | :kilobyte | :megabyte | :gigabyte | :terabyte
-  @type value_unit :: {number, Unit.t}
-  @type value_unit_atom :: {number, unit_atom}
+  @type any_unit :: unit_atom | Unit.t
 
   @doc """
   Converts a value for a specified %Unit or unit atom and converts it to the equivalent of another unit of measure.
@@ -63,15 +60,9 @@ defmodule Benchee.Conversion.Memory do
     iex> unit.name
     :megabyte
   """
-  @spec convert(value_unit | value_unit_atom, Unit.t | unit_atom) :: value_unit
-  def convert({value, %Unit{magnitude: current_magnitude}}, desired_unit = %Unit{magnitude: desired_magnitude}) do
-    multiplier = current_magnitude / desired_magnitude
-    {value * multiplier, desired_unit}
-  end
-  def convert({value, current_unit_atom}, desired_unit_atom) when is_atom(current_unit_atom) and is_atom(desired_unit_atom) do
-    current_value_unit = {value, unit_for(current_unit_atom)}
-    desired_unit = unit_for(desired_unit_atom)
-    convert(current_value_unit, desired_unit)
+  @spec convert({number, any_unit}, any_unit) :: Scale.scaled_number
+  def convert(number_and_unit, desired_unit) do
+    Scale.convert number_and_unit, desired_unit, __MODULE__
   end
 
   # Scaling functions
@@ -215,7 +206,7 @@ defmodule Benchee.Conversion.Memory do
 
       iex> Benchee.Conversion.Memory.format({45.6789, :kilobyte})
       "45.68 KB"
-      
+
       iex> Benchee.Conversion.Memory.format {45.6789,
       ...>   %Benchee.Conversion.Unit{
       ...>     long: "Kilobytes", magnitude: 1024, label: "KB"}

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -45,7 +45,7 @@ defmodule Benchee.Conversion.Scale do
   Given the atom representation of a unit (`:hour`) return the appropriate
   `Benchee.Conversion.Unit` struct.
   """
-  @callback unit_for(unit_atom) :: unit
+  @callback unit_for(any_unit) :: unit
 
   @doc """
   Takes a tuple of a number and a unit and a unit to be converted to, returning

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -112,12 +112,12 @@ defmodule BencheeTest do
 
   test "integration super fast function print warnings" do
     output = capture_io fn ->
-      Benchee.run(%{"Sleeps" => fn -> 0 end}, time: 0.001, warmup: 0)
+      Benchee.run(%{"Constant" => fn -> 0 end}, time: 0.001, warmup: 0)
     end
 
     assert output =~ ~r/fast/
     assert output =~ ~r/unreliable/
-    assert output =~ ~r/^Sleeps\s+\d+.+\s+0\.\d+ μs/m
+    assert output =~ ~r/^Constant\s+\d+.+\s+[0-2]\.\d+ μs/m
   end
 
   test "integration super fast function warning is printed once per job" do


### PR DESCRIPTION
* Implements `convert` as part of the behaviour so that everything adopts it
* also makes `convert` work with %Unit{} and the unit atoms (along with it `unit_for`)
* includes a drive by fix for a test that was flaky for me locally when run with `coveralls`