### PR TITLE
Implementing extended options for console formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Provides you with the following **statistical data**:
 * **median**    - when all measured times are sorted, this is the middle value (or average of the two middle values when the number of samples is even). More stable than the average and somewhat more likely to be a typical value you see. (the lower the better)
 * **99th %**    - 99th percentile, 99% of all run times are less than this
 
+In addition, you can optionally output an extended set of statistics.
+* **minimum**     - the smallest (fastest) run time measured for the job
+* **maximum**     - the biggest (slowest) run time measured for the job
+* **sample size** - the number of run time measurements taken
+* **mode**        - the run time(s) that occur the most. Often one value, but can be multiple values if they occur the same amount of times. If no value occurs at least twice, this value will be nil.
+
 Benchee does not:
 
 * Keep results of previous runs and compare them (yet), if you want that have a look at [benchfella](https://github.com/alco/benchfella) or [bmark](https://github.com/joekain/bmark) until benchee gets that feature :)

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -13,30 +13,31 @@ defmodule Benchee.Configuration do
   }
 
   defstruct [
-    parallel:          1,
-    time:              5,
-    warmup:            2,
-    formatters:        [Console],
+    parallel:             1,
+    time:                 5,
+    warmup:               2,
+    formatters:           [Console],
     print: %{
-      benchmarking:    true,
-      configuration:   true,
-      fast_warning:    true
+      benchmarking:       true,
+      configuration:      true,
+      fast_warning:       true
     },
-    inputs:            nil,
+    inputs:               nil,
     # formatters should end up here but known once are still picked up at
     # the top level for now
     formatter_options: %{
       console: %{
-        comparison:    true
+        comparison:       true,
+        extended_options: false
       }
     },
-    unit_scaling:     :best,
+    unit_scaling:         :best,
     # If you/your plugin/whatever needs it your data can go here
-    assigns:           %{},
-    before_each:       nil,
-    after_each:        nil,
-    before_scenario:   nil,
-    after_scenario:    nil
+    assigns:              %{},
+    before_each:          nil,
+    after_each:           nil,
+    before_scenario:      nil,
+    after_scenario:       nil
   ]
 
   @type t :: %__MODULE__{
@@ -140,7 +141,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true}
+              console: %{comparison: true, extended_options: false}
             },
             unit_scaling: :best,
             assigns: %{},
@@ -168,7 +169,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true}
+              console: %{comparison: true, extended_options: false}
             },
             unit_scaling: :best,
             assigns: %{},
@@ -196,7 +197,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true}
+              console: %{comparison: true, extended_options: false}
             },
             unit_scaling: :best,
             assigns: %{},
@@ -233,7 +234,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: false},
+              console: %{comparison: false, extended_options: false},
               some: "option"
             },
             unit_scaling: :smallest,

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -28,7 +28,7 @@ defmodule Benchee.Configuration do
     formatter_options: %{
       console: %{
         comparison:       true,
-        extended_options: false
+        extended_statistics: false
       }
     },
     unit_scaling:         :best,
@@ -141,7 +141,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true, extended_options: false}
+              console: %{comparison: true, extended_statistics: false}
             },
             unit_scaling: :best,
             assigns: %{},
@@ -169,7 +169,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true, extended_options: false}
+              console: %{comparison: true, extended_statistics: false}
             },
             unit_scaling: :best,
             assigns: %{},
@@ -197,7 +197,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true, extended_options: false}
+              console: %{comparison: true, extended_statistics: false}
             },
             unit_scaling: :best,
             assigns: %{},
@@ -234,7 +234,7 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: false, extended_options: false},
+              console: %{comparison: false, extended_statistics: false},
               some: "option"
             },
             unit_scaling: :smallest,

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -19,6 +19,10 @@ defmodule Benchee.Formatters.Console do
   @deviation_width 11
   @median_width 15
   @percentile_width 15
+  @minimum_width 15
+  @maximum_width 15
+  @sample_size_width 15
+  @mode_width 25
 
   @doc """
   Formats the benchmark statistics using `Benchee.Formatters.Console.format/1`
@@ -59,7 +63,7 @@ defmodule Benchee.Formatters.Console do
   ...>   scenarios: scenarios,
   ...>   configuration: %Benchee.Configuration{
   ...>     formatter_options: %{
-  ...>       console: %{comparison: false}
+  ...>       console: %{comparison: false, extended_options: false}
   ...>     },
   ...>     unit_scaling: :best
   ...>   }
@@ -120,20 +124,26 @@ defmodule Benchee.Formatters.Console do
   iex> scenarios = [
   ...>   %Benchee.Benchmark.Scenario{
   ...>     job_name: "My Job", run_time_statistics: %Benchee.Statistics{
-  ...>       average: 200.0, ips: 5000.0,std_dev_ratio: 0.1, median: 190.0, percentiles: %{99 => 300.1}
+  ...>       average: 200.0, ips: 5000.0,std_dev_ratio: 0.1, median: 190.0, percentiles: %{99 => 300.1},
+  ...>       minimum: 100.1, maximum: 200.2, sample_size: 10_101, mode: 333.2
   ...>     }
   ...>   },
   ...>   %Benchee.Benchmark.Scenario{
   ...>     job_name: "Job 2", run_time_statistics: %Benchee.Statistics{
-  ...>       average: 400.0, ips: 2500.0, std_dev_ratio: 0.2, median: 390.0, percentiles: %{99 => 500.1}
+  ...>       average: 400.0, ips: 2500.0, std_dev_ratio: 0.2, median: 390.0, percentiles: %{99 => 500.1},
+  ...>       minimum: 200.2, maximum: 400.4, sample_size: 20_202, mode: [612.3, 554.1]
   ...>     }
   ...>   }
   ...> ]
-  iex> configuration = %{comparison: false, unit_scaling: :best}
+  iex> configuration = %{comparison: false, unit_scaling: :best, extended_options: true}
   iex> Benchee.Formatters.Console.format_scenarios(scenarios, configuration)
   ["\nName             ips        average  deviation         median         99th %\n",
   "My Job           5 K         200 μs    ±10.00%         190 μs      300.10 μs\n",
-  "Job 2         2.50 K         400 μs    ±20.00%         390 μs      500.10 μs\n"]
+  "Job 2         2.50 K         400 μs    ±20.00%         390 μs      500.10 μs\n",
+  "\nExtended options: \n",
+  "\nName           minimum        maximum    sample size                     mode\n",
+  "My Job       100.10 μs      200.20 μs          10101                333.20 μs\n",
+  "Job 2        200.20 μs      400.40 μs          20202     612.30 μs, 554.10 μs\n"]
 
   ```
 
@@ -145,11 +155,65 @@ defmodule Benchee.Formatters.Console do
     units = Conversion.units(sorted_scenarios, scaling_strategy)
     label_width = label_width(sorted_scenarios)
 
-    [column_descriptors(label_width) |
+    output = [column_descriptors(label_width) |
       scenario_reports(sorted_scenarios, units, label_width)
       ++ comparison_report(sorted_scenarios, units, label_width, config)]
+
+    if config.extended_options do
+      output ++ [descriptor("Extended options") |
+        [extended_column_descriptors(label_width)]
+          ++ extended_options_reports(sorted_scenarios, units, label_width)]
+    else
+      output
+    end
   end
 
+  @spec extended_options_reports([Scenario.t], map, integer) :: [any, ...]
+  defp extended_options_reports(scenarios, units, label_width) do
+    Enum.map(scenarios, fn(scenario) ->
+              format_scenario_extended(scenario, units, label_width) end)
+  end
+
+  @spec format_scenario_extended(Scenario.t, map, integer) :: String.t
+  defp format_scenario_extended(%Scenario{
+                                  job_name: name,
+                                  run_time_statistics: %Statistics{
+                                    minimum:     minimum,
+                                    maximum:     maximum,
+                                    sample_size: sample_size,
+                                    mode:        mode
+                                  },
+                                },
+                                %{run_time: run_time_unit},
+                                label_width) do
+    "~*s~*ts~*ts~*ts~*ts\n"
+    |> :io_lib.format([
+      -label_width, name,
+      @minimum_width, run_time_out(minimum, run_time_unit),
+      @maximum_width, run_time_out(maximum, run_time_unit),
+      @sample_size_width, to_string(sample_size),
+      @mode_width, mode_out(mode, run_time_unit)])
+    |> to_string
+  end
+
+  @spec mode_out([number], Benchee.Conversion.Unit.t) :: String.t
+  defp mode_out(modes, run_time_unit) when is_list(modes) do
+    Enum.map_join(modes, ", ", fn(mode) -> run_time_out(mode, run_time_unit) end)
+  end
+  defp mode_out(mode, run_time_unit) when is_number(mode) do
+    run_time_out(mode, run_time_unit)
+  end
+
+  @spec extended_column_descriptors(integer) :: String.t
+  defp extended_column_descriptors(label_width) do
+    "\n~*s~*s~*s~*s~*s\n"
+    |> :io_lib.format([-label_width, "Name", @minimum_width, "minimum",
+                       @maximum_width, "maximum", @sample_size_width, "sample size",
+                       @mode_width, "mode"])
+    |> to_string
+  end
+
+  @spec column_descriptors(integer) :: String.t
   defp column_descriptors(label_width) do
     "\n~*s~*s~*s~*s~*s~*s\n"
     |> :io_lib.format([-label_width, "Name", @ips_width, "ips",
@@ -202,8 +266,8 @@ defmodule Benchee.Formatters.Console do
     Count.format({Count.scale(ips, unit), unit})
   end
 
-  defp run_time_out(average, unit) do
-    Duration.format({Duration.scale(average, unit), unit})
+  defp run_time_out(run_time, unit) do
+    Duration.format({Duration.scale(run_time, unit), unit})
   end
 
   defp deviation_out(std_dev_ratio) do
@@ -221,7 +285,7 @@ defmodule Benchee.Formatters.Console do
   end
   defp comparison_report([scenario | other_scenarios], units, label_width, _) do
     [
-      comparison_descriptor(),
+      descriptor("Comparison"),
       reference_report(scenario, units, label_width) |
       comparisons(scenario, units, label_width, other_scenarios)
     ]
@@ -256,7 +320,8 @@ defmodule Benchee.Formatters.Console do
     |> to_string
   end
 
-  defp comparison_descriptor do
-    "\nComparison: \n"
+  @spec descriptor(String.t) :: String.t
+  defp descriptor(header_str) do
+    "\n#{header_str}: \n"
   end
 end

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -36,7 +36,10 @@ defmodule Benchee.ConfigurationTest do
     test "it can be adjusted with a map" do
       user_options = %{
         time: 10,
-        formatter_options: %{custom: %{option: true}}
+        formatter_options: %{
+          custom: %{option: true},
+          console: %{extended_options: true}
+        }
       }
 
       result = deep_merge(@default_config, user_options)
@@ -45,7 +48,7 @@ defmodule Benchee.ConfigurationTest do
         time: 10,
         formatter_options: %{
           custom: %{option: true},
-          console: %{comparison: true}
+          console: %{comparison: true, extended_options: true}
         }
       }
 

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -38,7 +38,7 @@ defmodule Benchee.ConfigurationTest do
         time: 10,
         formatter_options: %{
           custom: %{option: true},
-          console: %{extended_options: true}
+          console: %{extended_statistics: true}
         }
       }
 
@@ -48,7 +48,7 @@ defmodule Benchee.ConfigurationTest do
         time: 10,
         formatter_options: %{
           custom: %{option: true},
-          console: %{comparison: true, extended_options: true}
+          console: %{comparison: true, extended_statistics: true}
         }
       }
 

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -10,15 +10,20 @@ defmodule Benchee.Formatters.ConsoleTest do
   @console_config %{
     comparison: true,
     unit_scaling: :best,
-    extended_options: false
+    extended_statistics: false
   }
   @console_config_extended_params %{
     comparison: true,
     unit_scaling: :best,
-    extended_options: true
+    extended_statistics: true
   }
   @config %Benchee.Configuration{
-    formatter_options: %{console: %{comparison: true, extended_options: false}}
+    formatter_options: %{
+      console: %{
+        comparison: true,
+        extended_statistics: false
+      }
+    }
   }
   describe ".output" do
     test "formats and prints the results right to the console" do
@@ -65,7 +70,7 @@ defmodule Benchee.Formatters.ConsoleTest do
   end
 
   describe ".format_scenarios" do
-    test "displays extended options" do
+    test "displays extended statistics" do
       scenarios = [
         %Scenario{
           job_name: "First job",
@@ -83,22 +88,22 @@ defmodule Benchee.Formatters.ConsoleTest do
         }
       ]
 
-      [_header1, _result1, descriptor1, descriptor2, result2] =
+      [_header1, _result1, header1, header2, result2] =
         Console.format_scenarios(scenarios, @console_config_extended_params)
 
-        assert descriptor1 =~ ~r/Extended options: /
-        assert descriptor2 =~ ~r/minimum/
-        assert descriptor2 =~ ~r/maximum/
-        assert descriptor2 =~ ~r/sample size/
-        assert descriptor2 =~ ~r/mode/
+        assert header1 =~ ~r/Extended statistics: /
+        assert header2 =~ ~r/minimum/
+        assert header2 =~ ~r/maximum/
+        assert header2 =~ ~r/sample size/
+        assert header2 =~ ~r/mode/
         assert result2 =~ ~r/First job/
         assert result2 =~ ~r/111.10/
         assert result2 =~ ~r/333.30/
-        assert result2 =~ ~r/50000/
+        assert result2 =~ ~r/50 K/
         assert result2 =~ ~r/201.20/
     end
 
-    test "displays extended options with multiple mode ouput" do
+    test "displays extended statistics with multiple mode ouput" do
       scenarios = [
         %Scenario{
           job_name: "First job",
@@ -116,20 +121,34 @@ defmodule Benchee.Formatters.ConsoleTest do
         }
       ]
 
-      [_header1, _result1, descriptor1, descriptor2, result2] =
+      [_header1, _result1, _header2, _header3, result2] =
         Console.format_scenarios(scenarios, @console_config_extended_params)
 
-        assert descriptor1 =~ ~r/Extended options: /
-        assert descriptor2 =~ ~r/minimum/
-        assert descriptor2 =~ ~r/maximum/
-        assert descriptor2 =~ ~r/sample size/
-        assert descriptor2 =~ ~r/mode/
-        assert result2 =~ ~r/First job/
-        assert result2 =~ ~r/111.10/
-        assert result2 =~ ~r/333.30/
-        assert result2 =~ ~r/50000/
-        assert result2 =~ ~r/201.20/
-        assert result2 =~ ~r/205.55/
+        assert result2 =~ ~r/201.20 μs/
+        assert result2 =~ ~r/205.55 μs/
+    end
+
+    test "displays N/A when no mode exists" do
+      scenarios = [
+        %Scenario{
+          job_name: "First job",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1},
+            minimum: 111.1,
+            maximum: 333.3,
+            sample_size: 50_000
+          }
+        }
+      ]
+
+      [_header1, _result1, _header2, _header3, result2] =
+        Console.format_scenarios(scenarios, @console_config_extended_params)
+
+        assert result2 =~ ~r/None/
     end
 
     test "sorts the the given stats fastest to slowest" do
@@ -291,7 +310,7 @@ defmodule Benchee.Formatters.ConsoleTest do
                   %{
                     comparison:       false,
                     unit_scaling:     :best,
-                    extended_options: false
+                    extended_statistics: false
                   })
 
       refute Regex.match? ~r/Comparison/i, output

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -7,9 +7,18 @@ defmodule Benchee.Formatters.ConsoleTest do
   alias Benchee.Formatters.Console
   alias Benchee.{Suite, Statistics, Benchmark.Scenario}
 
-  @console_config %{comparison: true, unit_scaling: :best}
+  @console_config %{
+    comparison: true,
+    unit_scaling: :best,
+    extended_options: false
+  }
+  @console_config_extended_params %{
+    comparison: true,
+    unit_scaling: :best,
+    extended_options: true
+  }
   @config %Benchee.Configuration{
-    formatter_options: %{console: %{comparison: true}}
+    formatter_options: %{console: %{comparison: true, extended_options: false}}
   }
   describe ".output" do
     test "formats and prints the results right to the console" do
@@ -56,6 +65,73 @@ defmodule Benchee.Formatters.ConsoleTest do
   end
 
   describe ".format_scenarios" do
+    test "displays extended options" do
+      scenarios = [
+        %Scenario{
+          job_name: "First job",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1},
+            minimum: 111.1,
+            maximum: 333.3,
+            mode: 201.2,
+            sample_size: 50_000
+          }
+        }
+      ]
+
+      [_header1, _result1, descriptor1, descriptor2, result2] =
+        Console.format_scenarios(scenarios, @console_config_extended_params)
+
+        assert descriptor1 =~ ~r/Extended options: /
+        assert descriptor2 =~ ~r/minimum/
+        assert descriptor2 =~ ~r/maximum/
+        assert descriptor2 =~ ~r/sample size/
+        assert descriptor2 =~ ~r/mode/
+        assert result2 =~ ~r/First job/
+        assert result2 =~ ~r/111.10/
+        assert result2 =~ ~r/333.30/
+        assert result2 =~ ~r/50000/
+        assert result2 =~ ~r/201.20/
+    end
+
+    test "displays extended options with multiple mode ouput" do
+      scenarios = [
+        %Scenario{
+          job_name: "First job",
+          run_time_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1},
+            minimum: 111.1,
+            maximum: 333.3,
+            mode: [201.2, 205.55],
+            sample_size: 50_000
+          }
+        }
+      ]
+
+      [_header1, _result1, descriptor1, descriptor2, result2] =
+        Console.format_scenarios(scenarios, @console_config_extended_params)
+
+        assert descriptor1 =~ ~r/Extended options: /
+        assert descriptor2 =~ ~r/minimum/
+        assert descriptor2 =~ ~r/maximum/
+        assert descriptor2 =~ ~r/sample size/
+        assert descriptor2 =~ ~r/mode/
+        assert result2 =~ ~r/First job/
+        assert result2 =~ ~r/111.10/
+        assert result2 =~ ~r/333.30/
+        assert result2 =~ ~r/50000/
+        assert result2 =~ ~r/201.20/
+        assert result2 =~ ~r/205.55/
+    end
+
     test "sorts the the given stats fastest to slowest" do
       scenarios = [
         %Scenario{
@@ -213,8 +289,9 @@ defmodule Benchee.Formatters.ConsoleTest do
       output =  Enum.join Console.format_scenarios(
                   scenarios,
                   %{
-                    comparison:   false,
-                    unit_scaling: :best
+                    comparison:       false,
+                    unit_scaling:     :best,
+                    extended_options: false
                   })
 
       refute Regex.match? ~r/Comparison/i, output


### PR DESCRIPTION
Closes #50 

## Overview
Benchee collects statistics that may not always need to be shown to the general user but could still be beneficial to some. This PR introduces the capability to optionally display these "extended statistics", which consist of: minimum runtime, maximum runtime, mode runtime, and sample size. This PR implements it as a single boolean configuration value that when true will enable the console formatter to output all of the mentioned extended statistics. False, obviously will not display them. 

## Open questions
* Should displaying these be turned off by default, as it is implemented in this PR?
* Right now I do not have any formatting for sample size, merely just running the number through ```to_string/1``` should this be formatted perhaps?
* I felt that both the regular scenario and extended options formatter methods within the console formatter module could be generalized. I tried my hand at dissolving the methods involved for each into a set of methods that could handle any input of scenario data and set of options to ouput. I do have a small hang up on how to call the numeric formatting methods with the correct set of params for each statistic being formatted, e.g. when as ips => call ips_out() vs some other method. [Here is a branch](https://github.com/PragTob/benchee/compare/master...lwalter:feature/dynamic-extended-options) that captures what I was trying to accomplish, if you have the spare time please take a look as this implementation might result in a more re-usable, condense console formatter module.