### PR TITLE
use Formatter to avoid extra logic in `output/1` + repetition

### DIFF
--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -31,6 +31,25 @@ defmodule Benchee.Formatter do
   """
   @callback output(Suite.t) :: Suite.t
 
+  defmacro __using__(_) do
+    quote location: :keep do
+      @behaviour Benchee.Formatter
+
+      @doc """
+      Combines `format/1` and `write/1` into a single convenience function that
+      is also chainable (as it takes a suite and returns a suite).
+      """
+      @spec output(Benchee.Suite.t) :: Benchee.Suite.t
+      def output(suite) do
+        :ok = suite
+              |> format
+              |> write
+
+        suite
+      end
+    end
+  end
+
   @doc """
   Invokes `format/1` and `write/1` as defined by the `Benchee.Formatter`
   behaviour. The output for all formatters are generated in parallel, and then

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -4,7 +4,7 @@ defmodule Benchee.Formatters.Console do
   output through `IO.write` on the console.
   """
 
-  @behaviour Benchee.Formatter
+  use Benchee.Formatter
 
   alias Benchee.{
     Statistics, Suite, Benchmark.Scenario, Configuration, Conversion
@@ -19,19 +19,6 @@ defmodule Benchee.Formatters.Console do
   @deviation_width 11
   @median_width 15
   @percentile_width 15
-
-  @doc """
-  Formats the benchmark statistics using `Benchee.Formatters.Console.format/1`
-  and then prints it out directly to the console using `IO.write/1`
-  """
-  @spec output(Suite.t) :: Suite.t
-  def output(suite = %Suite{}) do
-    :ok = suite
-          |> format
-          |> write
-
-    suite
-  end
 
   @doc """
   Formats the benchmark statistics to a report suitable for output on the CLI.

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -186,6 +186,23 @@ defmodule BencheeTest do
     readme_sample_asserts output
   end
 
+  test "formatters can be supplied as the output/1 function" do
+    output = capture_io fn ->
+      list = Enum.to_list(1..10_000)
+      map_fun = fn(i) -> [i, i * i] end
+
+      Benchee.run(%{
+        "flat_map"    => fn -> Enum.flat_map(list, map_fun) end,
+        "map.flatten" =>
+          fn -> list |> Enum.map(map_fun) |> List.flatten end
+      }, time: 0.01,
+         warmup: 0.005,
+         formatters: [&Benchee.Formatters.Console.output/1])
+    end
+
+    readme_sample_asserts output
+  end
+
   test "for formatters specified as modules format/1 and write/1 are called" do
     capture_io fn ->
       Benchee.run(%{


### PR DESCRIPTION
Noticed it in the HTML formatter that the output/1 function had
added logic which then wouldn't be called in the new "specify
a formatter as a module and we'll call `format/1` and `output/1`
for you". `output/1` should really only do this, nothing more.

This helps us enforce this and avoid code duplication.