### PR TITLE
Help! Why doesn't dialyzer like this spec? :(

### DIFF
--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -170,6 +170,8 @@ defmodule Benchee.Formatters.Console do
     end)
   end
 
+  @spec format_scenario_extended(Scenario.t, unit_per_statistic, integer)
+    :: String.t
   defp format_scenario_extended(%Scenario{
                                   job_name: name,
                                   run_time_statistics: %Statistics{

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -193,7 +193,7 @@ defmodule Benchee.Formatters.Console do
     |> to_string
   end
 
-  @spec mode_out([number], Benchee.Conversion.Unit.t) :: String.t
+  @spec mode_out(Statistics.mode, Benchee.Conversion.Unit.t) :: String.t
   defp mode_out(modes, _run_time_unit) when is_nil(modes) do
     "None"
   end

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -21,6 +21,8 @@ defmodule Benchee.Statistics do
     :sample_size
   ]
 
+  @type mode :: [number] | number | nil
+
   @type t :: %__MODULE__{
     average: float,
     ips: float,
@@ -29,7 +31,7 @@ defmodule Benchee.Statistics do
     std_dev_ips: float,
     median: number,
     percentiles: %{number => float},
-    mode: number,
+    mode: mode,
     minimum: number,
     maximum: number,
     sample_size: integer


### PR DESCRIPTION
The following line was originally in #153 and we dropped the type spec cause we couldn't get it to work. It would fail on all Erlang versions that aren't 18.3.

Basically it is the following (the only place where the offending function is called):

```elixir
  @spec extended_statistics([Scenario.t], unit_per_statistic, integer)
    :: [String.t]
  defp extended_statistics(scenarios, units, label_width) do
    Enum.map(scenarios, fn(scenario) ->
      format_scenario_extended(scenario, units, label_width)
    end)
  end
  
  # problem seems to be Scenario.t, pattern match on Scenario omitted for brevity
  @spec format_scenario_extended(Scenario.t, unit_per_statistic, integer)
    :: String.t
  defp format_scenario_extended(%Scenario{}, %{run_time: run_time_unit}, label_width) do
    "~*s~*ts~*ts~*ts~*ts\n"
    |> :io_lib.format([lots_of_options])
    |> to_string
  end
```

We get the following error:

```
lib/benchee/formatters/console.ex:173: Invalid type specification for function 'Elixir.Benchee.Formatters.Console':format_scenario_extended/3. The success typing is (#{'__struct__':='Elixir.Benchee.Benchmark.Scenario', 'job_name':=_, 'run_time_statistics':=#{'__struct__':='Elixir.Benchee.Statistics', 'maximum':=number(), 'minimum':=number(), 'mode':=[number()], 'sample_size':=_, _=>_}, _=>_},#{'ips':=#{'__struct__':='Elixir.Benchee.Conversion.Unit', 'label':=binary(), 'long':=binary(), 'magnitude':=non_neg_integer(), 'name':=atom()}, 'run_time':=#{'__struct__':='Elixir.Benchee.Conversion.Unit', 'label':=binary(), 'long':=binary(), 'magnitude':=non_neg_integer(), 'name':=atom()}},integer()) -> binary(
```

The problem seems to be with dialyzers interpretation what `Scenario.t` is. If it is exchanged against `any` or `map` dialyzer instead complains about underspecs: 

```
lib/benchee/formatters/console.ex:173: Type specification 'Elixir.Benchee.Formatters.Console':format_scenario_extended(map(),unit_per_statistic(),integer()) -> 'Elixir.String':t() is a supertype of the success typing: 'Elixir.Benchee.Formatters.Console':format_scenario_extended(#{'__struct__':='Elixir.Benchee.Benchmark.Scenario', 'job_name':=_, 'run_time_statistics':=#{'__struct__':='Elixir.Benchee.Statistics', 'maximum':=number(), 'minimum':=number(), 'mode':=[number()], 'sample_size':=_, _=>_}, _=>_},#{'ips':=#{'__struct__':='Elixir.Benchee.Conversion.Unit', 'label':=binary(), 'long':=binary(), 'magnitude':=non_neg_integer(), 'name':=atom()}, 'run_time':=#{'__struct__':='Elixir.Benchee.Conversion.Unit', 'label':=binary(), 'long':=binary(), 'magnitude':=non_neg_integer(), 'name':=atom()}},integer()) -> binary()
```

---------------------------------------------------------

One of the weirdest things about this is that we have virtually the same structure elsewhere in the same file and it works just fine:

```elixir
  @spec scenario_reports([Scenario.t], unit_per_statistic, integer)
    :: [String.t]
  defp scenario_reports(scenarios, units, label_width) do
    Enum.map(scenarios, fn(scenario) ->
      format_scenario(scenario, units, label_width)
    end)
  end

  # pattern match on scenario omitted for brevity
  @spec format_scenario(Scenario.t, unit_per_statistic, integer) :: String.t
  defp format_scenario(%Scenario{},
                       %{run_time: run_time_unit,
                         ips:      ips_unit,
                       }, label_width) do
    "~*s~*ts~*ts~*ts~*ts~*ts\n"
    |> :io_lib.format([options])
    |> to_string
  end
```

So umm **help** - help is rewarded with gratefulness and cute bunny pictures. Bonus points if you can lay out how to debug something like this :)

![img_20171028_173235](https://user-images.githubusercontent.com/606517/32144048-41a60226-bcb3-11e7-985a-095186261506.jpg)
