### PR TITLE
Measure memory 3

### DIFF
--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -191,7 +191,7 @@ defmodule Benchee.Benchmark.Runner do
        )
        when current_time > end_time do
     # restore correct order - important for graphing
-    {Enum.reverse(run_times), memory_usages}
+    {Enum.reverse(run_times), Enum.reverse(memory_usages)}
   end
 
   defp do_benchmark(scenario, scenario_context, {run_times, memory_usages}) do

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -96,6 +96,24 @@ defmodule Benchee.Benchmark.RunnerTest do
 
       assert length(new_suite.scenarios) == 1
     end
+    test "measures the memory usage of a scenario" do
+      suite = test_suite(%Suite{configuration: %{time: 60_000, warmup: 10_000}})
+      new_suite =
+        suite
+        |> Benchmark.benchmark("Name", fn ->
+          Enum.map(0..1000, fn _ -> [12.23, 30.536, 30.632, 7398.3295] end)
+        end)
+        |> Benchmark.measure(TestPrinter)
+
+      memory_usages = List.first(new_suite.scenarios).memory_usages
+
+      assert length(memory_usages) > 0
+
+      negative_memory_usages =
+        Enum.filter(memory_usages, fn memory -> memory < 0 end)
+
+      assert negative_memory_usages == []
+    end
 
     test "very fast functions print a warning" do
       output =


### PR DESCRIPTION
I think `:erlang.process_info(self(), :memory)` was the trick! Using
that function, I got **no** negative values, and relatively consistent
memory usage. This just adds those measured values to our scenarios,
but doesn't do anything with them yet.

Here's a screenshot of the unique values I got after running the test
I added. It seems consistently giving us a highest value of 133952 for
the function we're measuring in the test.

For now I build this on top of #167 to make merging easier later on, so
just check the third commit if you want to see the new stuff.

![memory_usage](https://user-images.githubusercontent.com/8422484/34726467-6359606e-f554-11e7-9b05-17e4d7c5858d.png)

Encouraging progress!