### PR TITLE
Parallel bug fix alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.12.0 (2018-01-11)
+
+A small release fixing a somewhat nasty bug involving running benchmarks in
+parallel.
+
+### Bugfixes (User Facing)
+
+* If you were running benchmarks in parallel, you would see results for each
+parallel process you were running. So, if you were running **two** jobs, and
+setting your configuration to `parallel: 2`, you would see **four** results in the
+formatter. This is now correctly showing only the **two** jobs.
+
 ## 0.11.0 (2017-11-30)
 
 A tiny little release with a bugfix and MOARE statistics for the console formatter.

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -142,6 +142,11 @@ defmodule Benchee.Benchmark.Runner do
     end
   end
 
+  # `run_times` is kept separately from the `Scenario` so that for the
+  # `parallel` execution case we can easily concatenate and flatten the results
+  # of all processes. That's why we add them to the scenario once after
+  # measuring has finished. `scenario` is still needed in general for the
+  # benchmarking function, hooks etc.
   defp do_benchmark(_scenario,
                     %ScenarioContext{
                       current_time: current_time, end_time: end_time

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -78,6 +78,17 @@ defmodule Benchee.Benchmark.RunnerTest do
       assert length(run_times_for(new_suite, "")) >= 12
     end
 
+    test "combines results for parallel benchmarks into a single scenario" do
+      suite = test_suite(%Suite{configuration: %{parallel: 4, time: 60_000}})
+
+      new_suite =
+        suite
+        |> Benchmark.benchmark("", fn -> :timer.sleep(10) end)
+        |> Benchmark.measure(TestPrinter)
+
+      assert length(new_suite.scenarios) == 1
+    end
+
     test "very fast functions print a warning" do
       output = ExUnit.CaptureIO.capture_io fn ->
         %Suite{configuration: %{print: %{fast_warning: true}}}


### PR DESCRIPTION
Alternative to #167 / builds upon it - new PR as I didn't wanna go and revert the changes. Builds upon it (test and Changelog) :)

Instead of already updating the scenario throughout all the benchmarking, just return the run_times/measurements in the end - which is the perfect moment to `flatten` them and add them to the scenario as a whole. Also seems to simplify some code in some places, however adds an extra argument in some places. We can't get rid off `scenario` though, as it's needed for the function and other data.

Let me know what you think :)