### PR TITLE
Update to_filename function pattern

### DIFF
--- a/lib/benchee/utility/file_creation.ex
+++ b/lib/benchee/utility/file_creation.ex
@@ -68,6 +68,9 @@ defmodule Benchee.Utility.FileCreation do
       iex> Benchee.Utility.FileCreation.interleave("abc.csv", "Big Input")
       "abc_big_input.csv"
 
+      iex> Benchee.Utility.FileCreation.interleave("abc.csv", "String.length/1")
+      "abc_string_length_1.csv"
+
       iex> Benchee.Utility.FileCreation.interleave("bench/abc.csv", "Big Input")
       "bench/abc_big_input.csv"
 
@@ -123,7 +126,7 @@ defmodule Benchee.Utility.FileCreation do
     case name_string do
       ^no_input -> ""
       _         ->
-        String.downcase(String.replace(name_string, " ", "_"))
+        String.downcase(String.replace(name_string, ~r/[^0-9A-Z]/i, "_"))
     end
   end
 end


### PR DESCRIPTION
If you defines a benchmark job names like `String.length/1` and uses some formatter like [benchee_html](https://hex.pm/packages/benchee_html) will [fail silently](https://github.com/PragTob/benchee/blob/master/lib/benchee/utility/file_creation.ex#L38).

Examples:

```
iex> File.open("abc_string.length/1.csv", [:write, :utf8])
{:error, :enoent}

iex> File.open("abc_string_length_1.csv", [:write, :utf8])
{:ok, #PID<0.221.0>}
```

This pull request updates the pattern of the file name sanitizer.