### PR TITLE
Drop negative memory measurements

### DIFF
--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -215,6 +215,7 @@ defmodule Benchee.Benchmark.Runner do
 
   # We return nil if no memory measurement is performed so keep it empty
   defp updated_memory_usages(nil, memory_usages), do: memory_usages
+  defp updated_memory_usages(memory_usage, memory_usages) when memory_usage < 0, do: memory_usages
   defp updated_memory_usages(memory_usage, memory_usages), do: [memory_usage | memory_usages]
 
   defp iteration_measurements(


### PR DESCRIPTION
Sadly this isn't really testable in our current structure,
but the test isn't really worth that re-architecturing I think sooo

Also of course ideally we wouldn't need this - but this is a good
guard for now to not let bad values through.