### PR TITLE
Add extended stats for memory usage

### DIFF
--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -11,6 +11,7 @@ defmodule Benchee.Formatters.Console.Memory do
     Benchmark.Scenario,
     Conversion,
     Conversion.Unit,
+    Conversion.Count,
     Formatters.Console.Helpers
   }
 
@@ -21,6 +22,10 @@ defmodule Benchee.Formatters.Console.Memory do
   @deviation_width 11
   @median_width 15
   @percentile_width 15
+  @minimum_width 15
+  @maximum_width 15
+  @sample_size_width 15
+  @mode_width 25
 
   @doc """
   Formats the memory statistics to a report suitable for output on the CLI. If
@@ -39,7 +44,8 @@ defmodule Benchee.Formatters.Console.Memory do
       "\nMemory usage statistics:\n",
       column_descriptors(label_width, hide_statistics),
       scenario_reports(scenarios, units, label_width, hide_statistics),
-      comparison_report(scenarios, units, label_width, config, hide_statistics)
+      comparison_report(scenarios, units, label_width, config, hide_statistics),
+      extended_statistics_report(scenarios, units, label_width, config, hide_statistics)
     ])
   end
 
@@ -202,6 +208,67 @@ defmodule Benchee.Formatters.Console.Memory do
 
     "~*s~*s - ~.2fx memory usage\n"
     |> :io_lib.format([-label_width, name, @median_width, median_format, slower])
+    |> to_string
+  end
+
+  defp extended_statistics_report(_, _, _, %{extended_statistics: false}, _), do: []
+  defp extended_statistics_report(_, _, _, _, true), do: []
+
+  defp extended_statistics_report(scenarios, units, label_width, _config, _hide_statistics) do
+    [
+      Helpers.descriptor("Extended statistics"),
+      extended_column_descriptors(label_width)
+      | extended_statistics(scenarios, units, label_width)
+    ]
+  end
+
+  defp extended_column_descriptors(label_width) do
+    "\n~*s~*s~*s~*s~*s\n"
+    |> :io_lib.format([
+      -label_width,
+      "Name",
+      @minimum_width,
+      "minimum",
+      @maximum_width,
+      "maximum",
+      @sample_size_width,
+      "sample size",
+      @mode_width,
+      "mode"
+    ])
+    |> to_string
+  end
+
+  defp extended_statistics(scenarios, units, label_width) do
+    Enum.map(scenarios, fn scenario ->
+      format_scenario_extended(scenario, units, label_width)
+    end)
+  end
+
+  defp format_scenario_extended(scenario, %{memory: memory_unit}, label_width) do
+    %Scenario{
+      name: name,
+      memory_usage_statistics: %Statistics{
+        minimum: minimum,
+        maximum: maximum,
+        sample_size: sample_size,
+        mode: mode
+      }
+    } = scenario
+
+    "~*s~*ts~*ts~*ts~*ts\n"
+    |> :io_lib.format([
+      -label_width,
+      name,
+      @minimum_width,
+      Helpers.count_output(minimum, memory_unit),
+      @maximum_width,
+      Helpers.count_output(maximum, memory_unit),
+      @sample_size_width,
+      Count.format(sample_size),
+      @mode_width,
+      Helpers.mode_out(mode, memory_unit)
+    ])
     |> to_string
   end
 end

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -241,6 +241,46 @@ defmodule Benchee.Formatters.Console.MemoryTest do
       refute Regex.match?(~r/Comparison/i, output)
       refute Regex.match?(~r/average/i, output)
     end
+
+    test "displays extended statistics" do
+      scenarios = [
+        %Scenario{
+          name: "First job",
+          memory_usage_statistics: %Statistics{
+            average: 200.0,
+            ips: 5_000.0,
+            std_dev_ratio: 0.1,
+            median: 195.5,
+            percentiles: %{99 => 300.1},
+            minimum: 111.1,
+            maximum: 333.3,
+            mode: 201.2,
+            sample_size: 50_000
+          },
+          run_time_statistics: %Statistics{average: 100.0, ips: 1_000.0}
+        }
+      ]
+
+      params = %{
+        comparison: true,
+        unit_scaling: :best,
+        extended_statistics: true
+      }
+
+      output = Memory.format_scenarios(scenarios, params)
+      [_memory_title, _header1, _result1, title, header2, result2] = output
+
+      assert title =~ ~r/Extended statistics: /
+      assert header2 =~ ~r/minimum/
+      assert header2 =~ ~r/maximum/
+      assert header2 =~ ~r/sample size/
+      assert header2 =~ ~r/mode/
+      assert result2 =~ ~r/First job/
+      assert result2 =~ ~r/111.10/
+      assert result2 =~ ~r/333.30/
+      assert result2 =~ ~r/50 K/
+      assert result2 =~ ~r/201.20/
+    end
   end
 
   defp assert_column_width(name, string, expected_width) do

--- a/test/benchee/utility/file_creation_integration_test.exs
+++ b/test/benchee/utility/file_creation_integration_test.exs
@@ -21,6 +21,7 @@ defmodule Benchee.Utility.FileCreationIntegrationTest do
         assert_correct_files()
       after
         File.rm_rf! @directory
+        File.rm_rf! "testing"
       end
     end
 
@@ -30,6 +31,7 @@ defmodule Benchee.Utility.FileCreationIntegrationTest do
         assert_correct_files()
       after
         File.rm_rf! @directory
+        File.rm_rf! "testing"
       end
     end
 
@@ -41,6 +43,7 @@ defmodule Benchee.Utility.FileCreationIntegrationTest do
         assert output =~ @file_name_2
       after
         File.rm_rf! @directory
+        File.rm_rf! "testing"
       end
     end
 
@@ -52,6 +55,7 @@ defmodule Benchee.Utility.FileCreationIntegrationTest do
       assert File.exists? "#{@directory}/test_string_length_1.txt"
     after
       File.rm_rf! @directory
+      File.rm_rf! "testing"
     end
 
     defp assert_correct_files do
@@ -76,6 +80,7 @@ defmodule Benchee.Utility.FileCreationIntegrationTest do
         assert Enum.member?(file_names, @file_name_2)
       after
         File.rm_rf! @directory
+        File.rm_rf! "testing"
       end
     end
   end


### PR DESCRIPTION
Now if folks want to see the extended info for memory usage, they can!
It still won't show if there is no variation in the measurements.

Closes #191 