### PR TITLE
We only ever call MemoryMeasure with a single function as argument

### DIFF
--- a/test/benchee/memory_measure_test.exs
+++ b/test/benchee/memory_measure_test.exs
@@ -34,30 +34,4 @@ defmodule Benchee.MemoryMeasureTest do
       assert Enum.count(Process.list()) == starting_processes
     end
   end
-
-  describe "apply/3" do
-    test "returns the result of the function and the memory used (in bytes)" do
-      assert {memory_used, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]} =
-                MemoryMeasure.apply(Enum, :to_list, [1..10])
-
-      assert memory_used > 350
-      assert memory_used < 380
-    end
-
-    test "will not leak processes if the applied function raises an exception" do
-      starting_processes = Enum.count(Process.list())
-
-      # We're capturing the IO here so the error output doesn't clog up our
-      # tests. We don't want stuff in our green dots!!
-      # We also need to sleep for 1ms because the error output is coming from
-      # a separate process, so we need to wait for that to emit so we can
-      # capture it.
-      capture_io(fn ->
-        MemoryMeasure.apply(Enum, :to_list, ["abcdef"])
-        Process.sleep(1)
-      end)
-
-      assert Enum.count(Process.list()) == starting_processes
-    end
-  end
 end


### PR DESCRIPTION
Or is there a reason we need this that I'm missing? :)

(this PR is more of a question illustrated with code)