### PR TITLE
Handle calculation of statistics when given 0s

### DIFF
--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -137,12 +137,32 @@ defmodule Benchee.Conversion.Scale do
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
       iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :largest).name
       :million
+
+      iex> list = []
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      :one
+
+      iex> list = [nil]
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      :one
+
+      iex> list = [nil, nil, nil, nil]
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      :one
+
+      iex> list = [nil, nil, nil, nil, 2_000]
+      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      :thousand
   """
-  def best_unit([], module, _) do
+  def best_unit(measurements, module, options) do
+    do_best_unit(Enum.reject(measurements, &is_nil/1), module, options)
+  end
+
+  defp do_best_unit([], module, _) do
     module.base_unit
   end
 
-  def best_unit(list, module, opts) do
+  defp do_best_unit(list, module, opts) do
     case Keyword.get(opts, :strategy, :best) do
       :best     -> best_unit(list, module)
       :largest  -> largest_unit(list, module)

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -144,7 +144,6 @@ defmodule Benchee.Formatters.Console.Memory do
   end
 
   defp format_scenario(scenario, %{memory: memory_unit}, label_width, false) do
-    # IO.inspect(scenario)
     %Scenario{
       name: name,
       memory_usage_statistics: %Statistics{

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -12,6 +12,7 @@ defmodule Benchee.Formatters.Console.Memory do
     Conversion,
     Conversion.Unit,
     Conversion.Count,
+    Conversion.Memory,
     Formatters.Console.Helpers
   }
 
@@ -114,8 +115,29 @@ defmodule Benchee.Formatters.Console.Memory do
     end)
   end
 
+  @na "N/A"
+
   @spec format_scenario(Scenario.t(), unit_per_statistic, integer, boolean) :: String.t()
+  defp format_scenario(scenario, units, label_width, hide_statistics)
+
+  defp format_scenario(
+         scenario = %Scenario{memory_usage_statistics: %{sample_size: 0}},
+         _,
+         label_width,
+         _) do
+
+    "~*ts~*ts\n"
+    |> :io_lib.format([
+      -label_width,
+      scenario.name,
+      @average_width,
+      @na
+    ])
+    |> to_string
+  end
+
   defp format_scenario(scenario, %{memory: memory_unit}, label_width, false) do
+    # IO.inspect(scenario)
     %Scenario{
       name: name,
       memory_usage_statistics: %Statistics{
@@ -205,13 +227,18 @@ defmodule Benchee.Formatters.Console.Memory do
     end)
   end
 
-  defp calculate_slower_value(0, _), do: "N/A"
-  defp calculate_slower_value(_, 0), do: "N/A"
-  defp calculate_slower_value(job_median, reference_median), do: job_median / reference_median
+  defp calculate_slower_value(job_median, reference_median)
+        when job_median == 0 or is_nil(job_median) or reference_median == 0 or
+               is_nil(reference_median) do
+    @na
+  end
+  defp calculate_slower_value(job_median, reference_median) do
+    job_median / reference_median
+  end
 
-  defp format_comparison(scenario, %{memory: memory_unit}, label_width, "N/A") do
+  defp format_comparison(scenario, %{memory: memory_unit}, label_width, @na) do
     %Scenario{name: name, memory_usage_statistics: %Statistics{median: median}} = scenario
-    median_format = Helpers.duration_output(median, memory_unit)
+    median_format = memory_output(median, memory_unit)
 
     "~*s~*s\n"
     |> :io_lib.format([-label_width, name, @median_width, median_format])
@@ -225,6 +252,12 @@ defmodule Benchee.Formatters.Console.Memory do
     "~*s~*s - ~.2fx memory usage\n"
     |> :io_lib.format([-label_width, name, @median_width, median_format, slower])
     |> to_string
+  end
+
+  defp memory_output(nil, _unit), do: "N/A"
+
+  defp memory_output(memory, unit) do
+    Memory.format({Memory.scale(memory, unit), unit})
   end
 
   defp extended_statistics_report(_, _, _, %{extended_statistics: false}, _), do: []

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -126,14 +126,21 @@ defmodule Benchee.Formatters.Console.Memory do
          label_width,
          _) do
 
-    "~*ts~*ts\n"
-    |> :io_lib.format([
-      -label_width,
-      scenario.name,
-      @average_width,
-      @na
-    ])
-    |> to_string
+    warning =  "WARNING the scenario \"#{scenario.name}\" has no memory measurements!" <>
+               " This is probably a bug please report it!\n" <>
+               "https://github.com/PragTob/benchee/issues/new"
+
+    data =
+      "~*ts~*ts\n"
+      |> :io_lib.format([
+        -label_width,
+        scenario.name,
+        @average_width,
+        @na
+      ])
+      |> to_string
+
+    warning <> "\n" <> data
   end
 
   defp format_scenario(scenario, %{memory: memory_unit}, label_width, false) do

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -261,9 +261,10 @@ defmodule Benchee.Statistics do
     :math.sqrt(variance)
   end
 
-  defp add_ips(statistics = %__MODULE{sample_size: 0}), do: statistics
+  defp add_ips(statistics = %__MODULE__{sample_size: 0}), do: statistics
+  defp add_ips(statistics = %__MODULE__{average: 0.0}), do: statistics
   defp add_ips(statistics) do
-    ips = iterations_per_second(statistics.average)
+    ips = Duration.microseconds({1, :second}) / statistics.average
     standard_dev_ips = ips * statistics.std_dev_ratio
 
     %__MODULE__{
@@ -271,11 +272,6 @@ defmodule Benchee.Statistics do
       ips: ips,
       std_dev_ips: standard_dev_ips
     }
-  end
-
-  defp iterations_per_second(0.0), do: 0.0
-  defp iterations_per_second(average_microseconds) do
-    Duration.microseconds({1, :second}) / average_microseconds
   end
 
   @doc """

--- a/samples/memory_breaker.exs
+++ b/samples/memory_breaker.exs
@@ -1,0 +1,150 @@
+defmodule BenchKeyword do
+  @compile :inline_list_funcs
+
+  # def pop_throw(keywords, key, default \\ nil) when is_list(keywords) do
+  #   do_pop(keywords, key, [])
+  # catch
+  #   :not_found -> {default, keywords}
+  # end
+
+  # defp do_pop([{key, value} | rest], key, acc),
+  #   do: {value, :lists.reverse(acc, delete(rest, key))}
+  # defp do_pop([{_, _} = pair | rest], key, acc),
+  #   do: do_pop(rest, key, [pair | acc])
+  # defp do_pop([], _key, _acc),
+  #   do: throw(:not_found)
+
+  # def pop_ret(keywords, key, default \\ nil) when is_list(keywords) do
+  #   do_pop(keywords, key, [], keywords, default)
+  # end
+
+  # defp do_pop([{key, value} | rest], key, acc, _keywords, _default),
+  #   do: {value, :lists.reverse(acc, delete(rest, key))}
+  # defp do_pop([{_, _} = pair | rest], key, acc, keywords, default),
+  #   do: do_pop(rest, key, [pair | acc], keywords, default)
+  # defp do_pop([], _key, _acc, keywords, default),
+  #   do: {default, keywords}
+
+  # def pop(keywords, key, default \\ nil) when is_list(keywords) do
+  #   case fetch(keywords, key) do
+  #     {:ok, value} ->
+  #       {value, delete(keywords, key)}
+  #     :error ->
+  #       {default, keywords}
+  #   end
+  # end
+
+  # def pop2(keywords, key, default \\ nil) when is_list(keywords) do
+  #   case :lists.keyfind(key, 1, keywords) do
+  #     {^key, value} -> {value, delete2(keywords, key)}
+  #     false -> {default, keywords}
+  #   end
+  # end
+
+  # def fetch(keywords, key) when is_list(keywords) and is_atom(key) do
+  #   case :lists.keyfind(key, 1, keywords) do
+  #     {^key, value} -> {:ok, value}
+  #     false -> :error
+  #   end
+  # end
+
+  def delete_v0(keywords, key) when is_list(keywords) and is_atom(key) do
+    :lists.filter(fn {k, _} -> k != key end, keywords)
+  end
+
+  def delete_v1(keywords, key) when is_list(keywords) and is_atom(key) do
+    do_delete(keywords, key, _deleted? = false)
+  catch
+    :not_deleted -> keywords
+  end
+
+  defp do_delete([{key, _} | rest], key, _deleted?),
+    do: do_delete(rest, key, true)
+  defp do_delete([{_, _} = pair | rest], key, deleted?),
+    do: [pair | do_delete(rest, key, deleted?)]
+  defp do_delete([], _key, _deleted? = true),
+    do: []
+  defp do_delete([], _key, _deleted? = false),
+    do: throw(:not_deleted)
+
+
+  def delete_v2(keywords, key) when is_list(keywords) and is_atom(key) do
+    delete_v2_key(keywords, key, [])
+  end
+
+  defp delete_v2_key([{key, _} | tail], key, heads) do
+    delete_v2_key(tail, key, heads)
+  end
+
+  defp delete_v2_key([{_, _} = pair | tail], key, heads) do
+    delete_v2_key(tail, key, [pair | heads])
+  end
+
+  defp delete_v2_key([], _key, heads) do
+    :lists.reverse(heads)
+  end
+
+  def delete_v3(keywords, key) when is_list(keywords) and is_atom(key) do
+    case :lists.keymember(key, 1, keywords) do
+      true -> delete_v3_key(keywords, key, [])
+      _ -> keywords
+    end
+  end
+
+  defp delete_v3_key([{key, _} | tail], key, heads) do
+    delete_v3_key(tail, key, heads)
+  end
+
+  defp delete_v3_key([{_, _} = pair | tail], key, heads) do
+    delete_v3_key(tail, key, [pair | heads])
+  end
+
+  defp delete_v3_key([], _key, heads) do
+    :lists.reverse(heads)
+  end
+
+  def delete_v4(keywords, key) when is_list(keywords) and is_atom(key) do
+    case :lists.keymember(key, 1, keywords) do
+      true -> delete_v4_key(keywords, key)
+      _ -> keywords
+    end
+  end
+
+  defp delete_v4_key([{key, _} | tail], key) do
+    delete_v4_key(tail, key)
+  end
+
+  defp delete_v4_key([{_, _} = pair | tail], key) do
+    [pair | delete_v4_key(tail, key)]
+  end
+
+  defp delete_v4_key([], _key) do
+    []
+  end
+end
+
+# benches = %{
+#   "pop_throw" => fn {kv, key} -> BenchKeyword.pop_throw(kv, key) end,
+#   "pop_ret" => fn {kv, key} -> BenchKeyword.pop_ret(kv, key) end,
+#   "pop" => fn {kv, key} -> BenchKeyword.pop(kv, key) end,
+#   "pop2" => fn {kv, key} -> BenchKeyword.pop2(kv, key) end
+# }
+
+benches = %{
+  "delete old" => fn {kv, key} -> BenchKeyword.delete_v0(kv, key) end,
+  "delete throw" => fn {kv, key} -> BenchKeyword.delete_v1(kv, key) end,
+  "delete reverse" => fn {kv, key} -> BenchKeyword.delete_v2(kv, key) end,
+  "delete keymember reverse" => fn {kv, key} -> BenchKeyword.delete_v3(kv, key) end,
+  "delete keymember body" => fn {kv, key} -> BenchKeyword.delete_v4(kv, key) end
+}
+
+inputs = %{
+  "small miss" => {Enum.map(1..10, &{:"k#{&1}", &1}), :k11},
+  "small hit" => {Enum.map(1..10, &{:"k#{&1}", &1}), :k10},
+  "large miss" => {Enum.map(1..100, &{:"k#{&1}", &1}), :k101},
+  "large hit" => {Enum.map(1..100, &{:"k#{&1}", &1}), :k100},
+  "huge miss" => {Enum.map(1..10000, &{:"k#{&1}", &1}), :k10001},
+  "huge hit" => {Enum.map(1..10000, &{:"k#{&1}", &1}), :k10000}
+}
+
+Benchee.run(benches, inputs: inputs, print: [fast_warning: false], memory_time: 0.5, warmup: 0, time: 0)

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -333,6 +333,8 @@ defmodule Benchee.Formatters.Console.MemoryTest do
       assert output =~ "First"
       assert output =~ ~r/Second.+N\/A/i
       assert output =~ "N/A"
+      assert output =~ "WARNING"
+      assert output =~ "report"
     end
 
     test "it doesn't blow up if some come back with a median of 0.0" do

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -79,6 +79,7 @@ defmodule Benchee.StatistcsTest do
           memory_usages: @standard_deviation_sample
         }
       ]
+
       suite = Statistics.statistics(%Suite{scenarios: scenarios})
 
       [%Scenario{run_time_statistics: stats}] = suite.scenarios
@@ -93,6 +94,18 @@ defmodule Benchee.StatistcsTest do
       }
 
       assert %Suite{configuration: %{formatters: []}} = Statistics.statistics(suite)
+    end
+
+    @all_zeros [0, 0, 0, 0, 0]
+    test "doesn't blow up when all measurements are zeros (mostly memory measurement)" do
+      scenarios = [%Scenario{run_times: @all_zeros, memory_usages: @all_zeros}]
+      suite = Statistics.statistics(%Suite{scenarios: scenarios})
+
+      [%Scenario{run_time_statistics: run_time_stats, memory_usage_statistics: memory_stats}] =
+        suite.scenarios
+
+      assert run_time_stats.sample_size == 5
+      assert memory_stats.sample_size == 5
     end
 
     defp stats_for(suite, job_name, input_name) do

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -418,20 +418,6 @@ defmodule BencheeTest do
     refute output =~ "never execute me"
   end
 
-  test "does not blow up when only measuring memory times" do
-    output = capture_io fn ->
-      Benchee.run(
-        %{
-          "something" => fn -> Enum.map(1..100, fn i -> i + 1 end) end
-        },
-        time: 0, warmup: 0, memory_time: 0.001
-      )
-    end
-
-    refute output =~ ~r/ips/i # no runtime statistics displayed
-    assert output =~ ~r/memory.+statistics/i
-  end
-
   describe "save & load" do
     test "saving the suite to disk and restoring it" do
       save = [save: [path: "save.benchee", tag: "master"]]
@@ -525,6 +511,20 @@ defmodule BencheeTest do
 
       assert output =~ ~r/Memory usage statistics:/
       assert output =~ ~r/To List\s+[0-9.]{3,} K*B{1}/
+    end
+
+    test "does not blow up when only measuring memory times" do
+      output = capture_io fn ->
+        Benchee.run(
+          %{
+            "something" => fn -> Enum.map(1..100, fn i -> i + 1 end) end
+          },
+          time: 0, warmup: 0, memory_time: 0.001
+        )
+      end
+
+      refute output =~ ~r/ips/i # no runtime statistics displayed
+      assert output =~ ~r/memory.+statistics/i
     end
   end
 

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -418,6 +418,20 @@ defmodule BencheeTest do
     refute output =~ "never execute me"
   end
 
+  test "does not blow up when only measuring memory times" do
+    output = capture_io fn ->
+      Benchee.run(
+        %{
+          "something" => fn -> Enum.map(1..100, fn i -> i + 1 end) end
+        },
+        time: 0, warmup: 0, memory_time: 0.001
+      )
+    end
+
+    refute output =~ ~r/ips/i # no runtime statistics displayed
+    assert output =~ ~r/memory.+statistics/i
+  end
+
   describe "save & load" do
     test "saving the suite to disk and restoring it" do
       save = [save: [path: "save.benchee", tag: "master"]]


### PR DESCRIPTION
We hadn't handled the calculation of statistics when given a whole
bunch of 0s, which is a complication since we're doing a lot of
division in there. Technically if we're in a situation where we're
supposed to divide by 0 the answer is Infinity, but instead of
introducing that, for now I'm just returning 0 as well.

Addresses the first reported bug in #213.