### PR TITLE
fix(tags): Handle many tag names properly

### DIFF
--- a/lib/benchee/formatters/tagged_save.ex
+++ b/lib/benchee/formatters/tagged_save.ex
@@ -47,8 +47,11 @@ defmodule Benchee.Formatters.TaggedSave do
 
   defp get_maximum_tag_increaser(tags, desired_tag) do
     tags
+    |> Enum.uniq()
+    |> Kernel.--([desired_tag])
     |> Enum.map(fn tag -> String.replace(tag, desired_tag <> "-", "") end)
     |> Enum.map(&String.to_integer/1)
+    |> Kernel.++([0])
     |> Enum.max()
   end
 


### PR DESCRIPTION
When using this locally, once I got to three conflicts this code threw an error.
I didn't do that much investigation, but the intention behind the code seemed
pretty clear, so I just updated the utility.