### PR TITLE
Function call overhead

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -64,7 +64,7 @@
         # You can customize the priority of any check
         # Priority values are: `low, normal, high, higher`
         #
-        {Credo.Check.Design.AliasUsage, priority: :low},
+        {Credo.Check.Design.AliasUsage, false},
         # For some checks, you can also set other parameters
         #
         # If you don't want the `setup` and `test` macro calls in ExUnit tests

--- a/.exguard.exs
+++ b/.exguard.exs
@@ -9,6 +9,12 @@ guard("credo", run_on_start: true)
 |> ignore(deps)
 |> notification(:auto)
 
+guard("mix format", run_on_start: true)
+|> command("mix format --check-formatted")
+|> watch(project_files)
+|> ignore(deps)
+|> notification(:auto)
+
 guard("dialyzer", run_on_start: true)
 |> command("mix dialyzer --halt-exit-status")
 |> watch(project_files)

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ The available options are the following (also documented in [hexdocs](https://he
     in microseconds, and counts will be displayed in ones (this is
     equivalent to the behaviour Benchee had pre 0.5.0)
 * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the [hooks section](#hooks-setup-teardown-etc)
+* `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure tun time. Defaults to true.
 
 ### Measuring memory consumption
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The available options are the following (also documented in [hexdocs](https://he
     in microseconds, and counts will be displayed in ones (this is
     equivalent to the behaviour Benchee had pre 0.5.0)
 * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the [hooks section](#hooks-setup-teardown-etc)
-* `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure tun time. Defaults to true.
+* `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure run time. Defaults to true.
 
 ### Measuring memory consumption
 

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -49,7 +49,8 @@ defmodule Benchee.Benchmark.Runner do
     scenario_context = %ScenarioContext{
       config: %Configuration{
         time: @overhead_determination_time,
-        warmup: @overhead_determination_time
+        warmup: @overhead_determination_time,
+        print: %{fast_warning: false}
       }
     }
 

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -31,7 +31,12 @@ defmodule Benchee.Benchmark.Runner do
       Enum.each(scenarios, fn scenario -> pre_check(scenario, scenario_context) end)
     end
 
-    function_call_overhead = determine_function_call_overhead()
+    function_call_overhead =
+      if scenario_context.config.measure_function_call_overhead do
+        determine_function_call_overhead()
+      else
+        0
+      end
 
     scenario_context = %ScenarioContext{
       scenario_context

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -25,21 +25,21 @@ defmodule Benchee.Benchmark.Runner do
   """
   @spec run_scenarios([Scenario.t()], ScenarioContext.t()) :: [Scenario.t()]
   def run_scenarios(scenarios, scenario_context) do
-    Enum.each(scenarios, fn scenario -> pre_check(scenario, scenario_context) end)
+    if scenario_context.config.pre_check do
+      Enum.each(scenarios, fn scenario -> pre_check(scenario, scenario_context) end)
+    end
     Enum.map(scenarios, fn scenario -> parallel_benchmark(scenario, scenario_context) end)
   end
 
   # This will run the given scenario exactly once, including the before and
   # after hooks, to ensure the function can execute without raising an error.
-  defp pre_check(scenario, scenario_context = %ScenarioContext{config: %{pre_check: true}}) do
+  defp pre_check(scenario, scenario_context) do
     scenario_input = Hooks.run_before_scenario(scenario, scenario_context)
     scenario_context = %ScenarioContext{scenario_context | scenario_input: scenario_input}
     _ = measure(scenario, scenario_context, Measure.Time)
     _ = Hooks.run_after_scenario(scenario, scenario_context)
     nil
   end
-
-  defp pre_check(_, _), do: nil
 
   defp parallel_benchmark(
          scenario = %Scenario{job_name: job_name, input_name: input_name},

--- a/lib/benchee/benchmark/scenario_context.ex
+++ b/lib/benchee/benchmark/scenario_context.ex
@@ -9,8 +9,9 @@ defmodule Benchee.Benchmark.ScenarioContext do
     :current_time,
     :end_time,
     # before_scenario can alter the original input
-    :scenario_input,
-    num_iterations: 1
+    scenario_input: nil,
+    num_iterations: 1,
+    function_call_overhead: 0
   ]
 
   @type t :: %__MODULE__{
@@ -19,6 +20,7 @@ defmodule Benchee.Benchmark.ScenarioContext do
           current_time: pos_integer | nil,
           end_time: pos_integer | nil,
           scenario_input: any,
-          num_iterations: pos_integer
+          num_iterations: pos_integer,
+          function_call_overhead: pos_integer
         }
 end

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -144,7 +144,7 @@ defmodule Benchee.Configuration do
       in microseconds, and counts will be displayed in ones (this is
       equivalent to the behaviour Benchee had pre 0.5.0)
     * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the hooks section in the README
-    * `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure tun time. Defaults to true.
+    * `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure run time. Defaults to true.
 
   ## Examples
 

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -40,7 +40,8 @@ defmodule Benchee.Configuration do
             before_each: nil,
             after_each: nil,
             before_scenario: nil,
-            after_scenario: nil
+            after_scenario: nil,
+            measure_function_call_overhead: true
 
   @type t :: %__MODULE__{
           parallel: integer,
@@ -59,7 +60,8 @@ defmodule Benchee.Configuration do
           before_each: fun | nil,
           after_each: fun | nil,
           before_scenario: fun | nil,
-          after_scenario: fun | nil
+          after_scenario: fun | nil,
+          measure_function_call_overhead: boolean
         }
 
   @type user_configuration :: map | keyword
@@ -142,6 +144,7 @@ defmodule Benchee.Configuration do
       in microseconds, and counts will be displayed in ones (this is
       equivalent to the behaviour Benchee had pre 0.5.0)
     * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the hooks section in the README
+    * `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure tun time. Defaults to true.
 
   ## Examples
 

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -283,7 +283,7 @@ defmodule Benchee.Configuration do
       config
       |> standardized_user_configuration
       |> merge_with_defaults
-      |> convert_time_to_micro_s
+      |> convert_time_to_nano_s
       |> update_measure_memory
       |> save_option_conversion
 
@@ -320,7 +320,7 @@ defmodule Benchee.Configuration do
     DeepMerge.deep_merge(%Configuration{}, user_config)
   end
 
-  defp convert_time_to_micro_s(config) do
+  defp convert_time_to_nano_s(config) do
     Enum.reduce(@time_keys, config, fn key, new_config ->
       {_, new_config} =
         Map.get_and_update!(new_config, key, fn seconds ->

--- a/samples/fast_functions.exs
+++ b/samples/fast_functions.exs
@@ -1,80 +1,75 @@
-# This benchmark is not entirely recommended as the functions are way too fast
-# it's meant to show how this is not feasible or show improvements when I get
-# a new idea to improve this.
+# This benchmark is here to showcase behaviour with too fast functions.
+# You can see a lot of it reads _(wrong)_ as the compiler optimizes these cases to return
+# constants and thereby doesn't benchmark what you think it does.
 
 range = 1..10
+integer1 = :rand.uniform(100)
+integer2 = :rand.uniform(100)
+
 Benchee.run(%{
-  "Integer addition"          => fn -> 1 + 1 end,
-  "String concatention"       => fn -> "1" <> "1" end,
-  "adding a head to an array" => fn -> [1 | [1]] end,
-  "++ array concat"           => fn -> [1] ++ [1] end,
-  "noop"                      => fn -> 0 end,
-  "Enum.map(10)"              => fn -> Enum.map(range, fn(i) -> i end) end
+  "Integer addition (wrong)"          => fn -> 1 + 1 end,
+  "Integer addition"                  => fn -> integer1 + integer2 end,
+  "String concatention (wrong)"       => fn -> "1" <> "1" end,
+  "adding a head to an array (wrong)" => fn -> [1 | [1]] end,
+  "++ array concat (wrong)"           => fn -> [1] ++ [1] end,
+  "noop"                              => fn -> 0 end,
+  "Enum.map(10)"                      => fn -> Enum.map(range, fn(i) -> i end) end
 }, time: 1, warmup: 1, memory_time: 1)
 
+# See how the median of almost all options is 0 or 1 because they essentially do the same thing.
+# Randomizing values prevents these optimizations but is still very fast (see the high standard
+# deviation)
 #
-# Before  adding running fast functions multiple times, these where just too
-# damn fast and unstable, take a look at these consecutive runs with integer
-# addition going first or last and super high deviations.
-#
-# tobi@happy ~/github/benchee $ mix run samples/fast_functions.exs
-#
-# ** lots of complains about too fast function execution **
-#
-# Name                          ips            average        deviation      median
-# ++ array concat               82969267.26    0.0121μs       (±16.71%)      0.0120μs
-# adding a head to an array     82868502.33    0.0121μs       (±100.61%)     0.0120μs
-# String concatention           82845306.42    0.0121μs       (±62.76%)      0.0120μs
-# Integer addition              81872809.30    0.0122μs       (±24.77%)      0.0120μs
-# noop                          81112598.69    0.0123μs       (±147.62%)     0.0120μs
-# Enum.map (10)                 1423971.66     0.70μs         (±104.11%)     0.64μs
-#
+# tobi@speedy:~$ mix run samples/fast_functions.exs
+# Operating System: Linux"
+# CPU Information: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
+# Number of Available Cores: 8
+# Available memory: 15.61 GB
+# Elixir 1.6.4
+# Erlang 20.3
+
+# Benchmark suite executing with the following configuration:
+# warmup: 1 s
+# time: 1 s
+# memory time: 1 s
+# parallel: 1
+# inputs: none specified
+# Estimated total run time: 21 s
+
+
+# Benchmarking ++ array concat (wrong)...
+# Benchmarking Enum.map(10)...
+# Benchmarking Integer addition...
+# Benchmarking Integer addition (wrong)...
+# Benchmarking String concatention (wrong)...
+# Benchmarking adding a head to an array (wrong)...
+# Benchmarking noop...
+
+# Name                                        ips        average  deviation         median         99th %
+# Integer addition (wrong)               358.83 M        2.79 ns  ±1551.16%           0 ns          36 ns
+# noop                                   334.28 M        2.99 ns  ±1397.50%           0 ns          41 ns
+# adding a head to an array (wrong)      316.02 M        3.16 ns  ±1198.18%           0 ns          37 ns
+# ++ array concat (wrong)                307.24 M        3.25 ns   ±939.38%           0 ns          45 ns
+# String concatention (wrong)            268.45 M        3.73 ns   ±845.54%           1 ns          39 ns
+# Integer addition                        61.74 M       16.20 ns   ±235.69%          18 ns          59 ns
+# Enum.map(10)                             2.26 M      442.05 ns  ±2153.23%         364 ns         813 ns
+
 # Comparison:
-# ++ array concat               82969267.26
-# adding a head to an array     82868502.33     - 1.00x slower
-# String concatention           82845306.42     - 1.00x slower
-# Integer addition              81872809.30     - 1.01x slower
-# noop                          81112598.69     - 1.02x slower
-# Enum.map (10)                 1423971.66      - 58.27x slower
-#
-# ---------------------------------
-#
-# Name                          ips            average        deviation      median
-# Integer addition              18907117533.72 0.00μs         (±42193.83%)   0.0μs
-# ++ array concat               10817900457.67 0.00μs         (±32894.19%)   0.0μs
-# adding a head to an array     8340878133.10  0.00μs         (±85548.54%)   0.0μs
-# String concatention          7283864419.48  0.00μs         (±18597.06%)   0.0μs
-#
-# Comparison:
-# Integer addition              18907117533.72
-# ++ array concat               10817900457.67  - 1.75x slower
-# adding a head to an array     8340878133.10   - 2.27x slower
-# String concatention          7283864419.48   - 2.60x slower
-#
-# -------------------------------------------------------------------------
-#
-# Name                          ips            average        deviation      median
-# Integer addition              25569475324.68 0.00μs         (±104824.72%)  0.0μs
-# Console concatention          23438869668.25 0.00μs         (±105090.58%)  0.0μs
-# adding a head to an array     21958497787.61 0.00μs         (±129525.54%)  0.0μs
-# ++ array concat               19056476744.19 0.00μs         (±128997.79%)  0.0μs
-#
-# Comparison:
-# Integer addition              25569475324.68
-# String concatention          23438869668.25  - 1.09x slower
-# adding a head to an array     21958497787.61  - 1.16x slower
-# ++ array concat               19056476744.19  - 1.34x slower
-#
-# -------------------------------------------------------------------------
-#
-# Name                          ips            average        deviation      median
-# adding a head to an array     24128392592.59 0.00μs         (±34613.13%)   0.0μs
-# String concatention          20195554414.78 0.00μs         (±80819.68%)   0.0μs
-# ++ array concat               17945628942.49 0.00μs         (±30830.87%)   0.0μs
-# Integer addition              16174678807.95 0.00μs         (±74327.34%)   0.0μs
-#
-# Comparison:
-# adding a head to an array     24128392592.59
-# String concatention          20195554414.78  - 1.19x slower
-# ++ array concat               17945628942.49  - 1.34x slower
-# Integer addition              16174678807.95  - 1.49x slower
+# Integer addition (wrong)               358.83 M
+# noop                                   334.28 M - 1.07x slower
+# adding a head to an array (wrong)      316.02 M - 1.14x slower
+# ++ array concat (wrong)                307.24 M - 1.17x slower
+# String concatention (wrong)            268.45 M - 1.34x slower
+# Integer addition                        61.74 M - 5.81x slower
+# Enum.map(10)                             2.26 M - 158.62x slower
+
+# Memory usage statistics:
+
+# Name                                 Memory usage
+# Integer addition (wrong)                    616 B
+# noop                                        616 B - 1.00x memory usage
+# adding a head to an array (wrong)           616 B - 1.00x memory usage
+# ++ array concat (wrong)                     616 B - 1.00x memory usage
+# String concatention (wrong)                 616 B - 1.00x memory usage
+# Integer addition                            616 B - 1.00x memory usage
+# Enum.map(10)                                424 B - 0.69x memory usage

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -12,7 +12,8 @@ defmodule Benchee.Benchmark.RunnerTest do
     warmup: 20_000_000,
     inputs: nil,
     pre_check: false,
-    print: %{fast_warning: false, configuration: true}
+    print: %{fast_warning: false, configuration: true},
+    measure_function_call_overhead: false
   }
   @system %{
     elixir: "1.4.0",
@@ -182,7 +183,8 @@ defmodule Benchee.Benchmark.RunnerTest do
 
     test "very fast function times are almost 0 with function call overhead elimination" do
       suite =
-        test_suite()
+        %{configuration: %{measure_function_call_overhead: true}}
+        |> test_suite()
         |> Benchmark.benchmark("", fn -> 1 end)
         |> Benchmark.measure(TestPrinter)
         |> Benchee.statistics()

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -180,6 +180,19 @@ defmodule Benchee.Benchmark.RunnerTest do
       assert median < 1500
     end
 
+    test "very fast function times are almost 0 with function call overhead elimination" do
+      suite =
+        test_suite()
+        |> Benchmark.benchmark("", fn -> 1 end)
+        |> Benchmark.measure(TestPrinter)
+        |> Benchee.statistics()
+
+      [%{run_time_statistics: %{median: median}}] = suite.scenarios
+
+      # Should be 0 if it works correctly, give a bit of leeway
+      assert median <= 5
+    end
+
     @tag :performance
     test "doesn't take longer than advertised for very fast funs" do
       retrying(fn ->
@@ -326,7 +339,7 @@ defmodule Benchee.Benchmark.RunnerTest do
     # keep or add to them (adding to them makes no sense as they were run on a
     # different machine, just keeping them can be accomplished by loading them
     # after `measure`)
-    test "completely overrides existing runtimes" do
+    test "completely overrides existing run times" do
       suite = %Suite{
         scenarios: [
           %Scenario{

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -191,8 +191,9 @@ defmodule Benchee.Benchmark.RunnerTest do
 
       [%{run_time_statistics: %{median: median}}] = suite.scenarios
 
-      # Should be 0 if it works correctly, give a bit of leeway
-      assert median <= 5
+      # Should be 0 if it works correctly, give a bit of leeway - especially the appveyor CI
+      # with Windows has a tougher time here as it repeats the function call
+      assert median <= 35
     end
 
     @tag :performance

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -193,7 +193,7 @@ defmodule Benchee.Benchmark.RunnerTest do
 
       # Should be 0 if it works correctly, give a bit of leeway - especially the appveyor CI
       # with Windows has a tougher time here as it repeats the function call
-      assert median <= 35
+      assert median <= 60
     end
 
     @tag :performance

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -370,7 +370,7 @@ defmodule BencheeTest do
 
     assert output =~ @header_regex
 
-    # fast fnction warnings only appear on Windows because of none nanosecond precision
+    # fast function warnings only appear on Windows because of none nanosecond precision
     if windows?() do
       assert output =~ ~r/fast/
       assert output =~ ~r/unreliable/


### PR DESCRIPTION
Quite some drive by fixes in here :)

Had to add the configuration option so that it doesn't drive up our test times - these 0.02 seconds add up when you do it a hundred times!

Idea as a follow up: Show the measured overhead in the printed out configuration. That improves discoverability but also adds a place to show that someone has it intentionally turned off (it's opt out). However, that requires moving code around: Either move the printing into the runner (not really the right place) or move the inner part of the runner somewhere else so that it can be called from `Benchmark` and already displayed there and then passed into the runner.

Here it is in action, making it visible that a lot of the function are just optimized by the compiler to return a constant (which is great):

```
tobi@speedy:~/github/benchee(function-call-overhead)$ mix run samples/fast_functions.exs 
Operating System: Linux"
CPU Information: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
Number of Available Cores: 8
Available memory: 15.61 GB
Elixir 1.6.4
Erlang 20.3

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 1 s
memory time: 1 s
parallel: 1
inputs: none specified
Estimated total run time: 21 s


Benchmarking ++ array concat (wrong)...
Benchmarking Enum.map(10)...
Benchmarking Integer addition...
Benchmarking Integer addition (wrong)...
Benchmarking String concatention (wrong)...
Benchmarking adding a head to an array (wrong)...
Benchmarking noop...

Name                                        ips        average  deviation         median         99th %
Integer addition (wrong)               358.83 M        2.79 ns  ±1551.16%           0 ns          36 ns
noop                                   334.28 M        2.99 ns  ±1397.50%           0 ns          41 ns
adding a head to an array (wrong)      316.02 M        3.16 ns  ±1198.18%           0 ns          37 ns
++ array concat (wrong)                307.24 M        3.25 ns   ±939.38%           0 ns          45 ns
String concatention (wrong)            268.45 M        3.73 ns   ±845.54%           1 ns          39 ns
Integer addition                        61.74 M       16.20 ns   ±235.69%          18 ns          59 ns
Enum.map(10)                             2.26 M      442.05 ns  ±2153.23%         364 ns         813 ns

Comparison: 
Integer addition (wrong)               358.83 M
noop                                   334.28 M - 1.07x slower
adding a head to an array (wrong)      316.02 M - 1.14x slower
++ array concat (wrong)                307.24 M - 1.17x slower
String concatention (wrong)            268.45 M - 1.34x slower
Integer addition                        61.74 M - 5.81x slower
Enum.map(10)                             2.26 M - 158.62x slower

Memory usage statistics:

Name                                 Memory usage
Integer addition (wrong)                    616 B
noop                                        616 B - 1.00x memory usage
adding a head to an array (wrong)           616 B - 1.00x memory usage
++ array concat (wrong)                     616 B - 1.00x memory usage
String concatention (wrong)                 616 B - 1.00x memory usage
Integer addition                            616 B - 1.00x memory usage
Enum.map(10)                                424 B - 0.69x memory usage
```