### PR TITLE
Allow for customizable percentiles in extended statistics

### DIFF
--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -18,6 +18,7 @@ defmodule Benchee.Configuration do
             memory_time: 0.0,
             pre_check: false,
             formatters: [Console],
+            percentiles: [50, 99],
             print: %{
               benchmarking: true,
               configuration: true,
@@ -124,6 +125,9 @@ defmodule Benchee.Configuration do
       (x times slower than) is shown (true/false). Enabled by default.
       * `extended_statistics` - display more statistics, aka `minimum`,
       `maximum`, `sample_size` and `mode`. Disabled by default.
+    * `percentiles` - if you are using extended statistics and want to see the
+    results for certain percentiles of results beyond just the median.
+    Defaults to [50, 99] to calculate the 50th and 99th percentiles.
     * `:unit_scaling` - the strategy for choosing a unit for durations and
     counts. May or may not be implemented by a given formatter (The console
     formatter implements it). When scaling a value, Benchee finds the "best fit"
@@ -162,8 +166,12 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true, extended_statistics: false}
+              console: %{
+                comparison: true,
+                extended_statistics: false
+              }
             },
+            percentiles: [50, 99],
             unit_scaling: :best,
             assigns: %{},
             before_each: nil,
@@ -192,8 +200,12 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true, extended_statistics: false}
+              console: %{
+                comparison: true,
+                extended_statistics: false
+              }
             },
+            percentiles: [50, 99],
             unit_scaling: :best,
             assigns: %{},
             before_each: nil,
@@ -222,8 +234,12 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: true, extended_statistics: false}
+              console: %{
+                comparison: true,
+                extended_statistics: false
+              }
             },
+            percentiles: [50, 99],
             unit_scaling: :best,
             assigns: %{},
             before_each: nil,
@@ -261,9 +277,13 @@ defmodule Benchee.Configuration do
               configuration: true
             },
             formatter_options: %{
-              console: %{comparison: false, extended_statistics: false},
+              console: %{
+                comparison: false,
+                extended_statistics: false
+              },
               some: "option"
             },
+            percentiles: [50, 99],
             unit_scaling: :smallest,
             assigns: %{},
             before_each: nil,

--- a/lib/benchee/suite.ex
+++ b/lib/benchee/suite.ex
@@ -11,8 +11,8 @@ defmodule Benchee.Suite do
   configuration.
   """
   defstruct [
-    :configuration,
     :system,
+    configuration: %Benchee.Configuration{},
     scenarios: []
   ]
 

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -71,11 +71,14 @@ defmodule Benchee.ConfigurationTest do
         time: 10,
         formatter_options: %{
           custom: %{option: true},
-          console: %{comparison: true, extended_statistics: true}
+          console: %{
+            comparison: true,
+            extended_statistics: true
+          }
         }
       }
 
-      assert ^expected = result
+      assert expected == result
     end
 
     test "it just replaces when given another configuration" do


### PR DESCRIPTION
Before these were always set to 50 and 99, but now users can customize
the percentiles they want to see in extended statistics. We always need
the 50th percentile to get the median, so even if a user doesn't set
that, it will be calculated anyway.

Resolves #151 