### PR TITLE
Add warning when protocols are not consolidated

### DIFF
--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -20,6 +20,8 @@ defmodule Benchee.System do
       cpu_speed: cpu_speed()
     }
 
+    warn_about_performance_degrading_settings()
+
     %Suite{suite | system: system_info}
   end
 
@@ -163,5 +165,23 @@ defmodule Benchee.System do
     else
       output
     end
+  end
+
+  defp warn_about_performance_degrading_settings do
+    unless all_protocols_consolidated?() do
+      IO.puts("""
+      Not all of your protocols have been consolidated. In order to achieve the
+      best possible accuracy for benchmarks, please ensure protocol
+      consolidation is enabled in your benchmarking environment.
+      """)
+    end
+  end
+
+  defp all_protocols_consolidated? do
+    path = :code.lib_dir(:elixir, :ebin)
+
+    [path]
+    |> Protocol.extract_protocols()
+    |> Enum.all?(&Protocol.consolidated?/1)
   end
 end


### PR DESCRIPTION
This adds a warning when folks try to run benchmarks in environments
without protocol consolidation enabled.

I have no idea how to test this since you can't turn protocol
consolidation off at runtime, though. I did test this locally, and this
is the output I got:

```
~/sandbox/benchee   Issue-68±  mix run samples/run.exs
Not all of your protocols have been consolidated. In order to achieve the
best possible accuracy for benchmarks, please ensure protocol
consolidation is enabled in your benchmarking environment.

Operating System: macOS"
CPU Information: Intel(R) Core(TM) i5-4260U CPU @ 1.40GHz
Number of Available Cores: 4
Available memory: 8 GB
Elixir 1.6.4
Erlang 20.3

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 28 s


Benchmarking flat_map...
Benchmarking map.flatten...

Name                  ips        average  deviation         median         99th %
flat_map           1.31 K        0.76 ms    ±18.34%        0.73 ms        1.59 ms
map.flatten        0.68 K        1.47 ms    ±31.06%        1.27 ms        3.02 ms

Comparison:
flat_map           1.31 K
map.flatten        0.68 K - 1.92x slower

Memory usage statistics:

Name           Memory usage
flat_map          625.54 KB
map.flatten       781.85 KB - 1.25x memory usage

**All measurements for memory usage were the same**
```

Resolves #68 