### PR TITLE
Memory format crash

### DIFF
--- a/lib/benchee/benchmark/scenario.ex
+++ b/lib/benchee/benchmark/scenario.ex
@@ -63,7 +63,7 @@ defmodule Benchee.Benchmark.Scenario do
       iex> Scenario.display_name(%{job_name: "flat_map"})
       "flat_map"
   """
-  @spec display_name(map) :: String.t()
+  @spec display_name(t) :: String.t()
   def display_name(%{job_name: job_name, tag: nil}), do: job_name
   def display_name(%{job_name: job_name, tag: tag}), do: "#{job_name} (#{tag})"
   def display_name(%{job_name: job_name}), do: job_name

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -40,6 +40,10 @@ defmodule Benchee.Conversion.Format do
   custom separator string that will appear between the value and label in the
   formatted output. If no `separator/0` function exists, the default separator
   (a single space) will be used.
+
+      iex> Benchee.Conversion.Format.format({1.0, :kilobyte}, Benchee.Conversion.Memory)
+      "1 KB"
+
   """
   def format({count, unit = %Unit{}}) do
     format(count, label(unit), separator())
@@ -57,12 +61,6 @@ defmodule Benchee.Conversion.Format do
     number
     |> module.scale()
     |> format
-  end
-
-  def format(number) do
-    number
-    |> Scale.scale()
-    |> format()
   end
 
   @default_separator " "

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -41,24 +41,34 @@ defmodule Benchee.Conversion.Format do
   formatted output. If no `separator/0` function exists, the default separator
   (a single space) will be used.
   """
-  def format({count, unit = %Unit{}}, module) do
-    format(count, label(unit), separator(module))
+  def format({count, unit = %Unit{}}) do
+    format(count, label(unit), separator())
+  end
+
+  def format({count, unit = %Unit{}}, _module) do
+    format({count, unit})
   end
 
   def format({count, unit_atom}, module) do
-    format({count, module.unit_for(unit_atom)}, module)
+    format({count, module.unit_for(unit_atom)})
   end
 
   def format(number, module) do
     number
-    |> module.scale
-    |> format(module)
+    |> module.scale()
+    |> format
+  end
+
+  def format(number) do
+    number
+    |> Scale.scale()
+    |> format()
   end
 
   @default_separator " "
   # should we need it again, a customer separator could be returned
   # per module here
-  defp separator(_module) do
+  defp separator do
     @default_separator
   end
 

--- a/lib/benchee/formatters/console/helpers.ex
+++ b/lib/benchee/formatters/console/helpers.ex
@@ -4,7 +4,7 @@ defmodule Benchee.Formatters.Console.Helpers do
   memory usage statistics.
   """
 
-  alias Benchee.Conversion.{Count, DeviationPercent, Duration, Unit}
+  alias Benchee.Conversion.{Count, DeviationPercent, Duration, Format, Scale, Unit}
   alias Benchee.Statistics
 
   @type unit_per_statistic :: %{atom => Unit.t()}
@@ -18,11 +18,15 @@ defmodule Benchee.Formatters.Console.Helpers do
   end
 
   def mode_out(modes, run_time_unit) when is_list(modes) do
-    Enum.map_join(modes, ", ", fn mode -> duration_output(mode, run_time_unit) end)
+    Enum.map_join(modes, ", ", fn mode -> unit_output(mode, run_time_unit) end)
   end
 
   def mode_out(mode, run_time_unit) when is_number(mode) do
-    duration_output(mode, run_time_unit)
+    unit_output(mode, run_time_unit)
+  end
+
+  defp unit_output(value, unit) do
+    Format.format({Scale.scale(value, unit), unit})
   end
 
   def label_width(scenarios) do
@@ -37,10 +41,6 @@ defmodule Benchee.Formatters.Console.Helpers do
 
   def count_output(count, unit) do
     Count.format({Count.scale(count, unit), unit})
-  end
-
-  def duration_output(duration, unit) do
-    Duration.format({Duration.scale(duration, unit), unit})
   end
 
   def deviation_output(std_dev_ratio) do

--- a/lib/benchee/formatters/console/helpers.ex
+++ b/lib/benchee/formatters/console/helpers.ex
@@ -4,7 +4,7 @@ defmodule Benchee.Formatters.Console.Helpers do
   memory usage statistics.
   """
 
-  alias Benchee.Conversion.{Count, DeviationPercent, Duration, Format, Scale, Unit}
+  alias Benchee.Conversion.{Count, DeviationPercent, Format, Scale, Unit}
   alias Benchee.Statistics
 
   @type unit_per_statistic :: %{atom => Unit.t()}

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -162,13 +162,13 @@ defmodule Benchee.Formatters.Console.Memory do
       -label_width,
       name,
       @average_width,
-      Helpers.duration_output(average, memory_unit),
+      memory_output(average, memory_unit),
       @deviation_width,
       Helpers.deviation_output(std_dev_ratio),
       @median_width,
-      Helpers.duration_output(median, memory_unit),
+      memory_output(median, memory_unit),
       @percentile_width,
-      Helpers.duration_output(percentile_99, memory_unit)
+      memory_output(percentile_99, memory_unit)
     ])
     |> to_string
   end
@@ -186,7 +186,7 @@ defmodule Benchee.Formatters.Console.Memory do
       -label_width,
       name,
       @average_width,
-      Helpers.duration_output(average, memory_unit)
+      memory_output(average, memory_unit)
     ])
     |> to_string
   end
@@ -220,7 +220,7 @@ defmodule Benchee.Formatters.Console.Memory do
       -label_width,
       name,
       @median_width,
-      Helpers.duration_output(median, memory_unit)
+      memory_output(median, memory_unit)
     ])
     |> to_string
   end
@@ -257,7 +257,7 @@ defmodule Benchee.Formatters.Console.Memory do
 
   defp format_comparison(scenario, %{memory: memory_unit}, label_width, slower) do
     %Scenario{name: name, memory_usage_statistics: %Statistics{median: median}} = scenario
-    median_format = Helpers.duration_output(median, memory_unit)
+    median_format = memory_output(median, memory_unit)
 
     "~*s~*s - ~.2fx memory usage\n"
     |> :io_lib.format([-label_width, name, @median_width, median_format, slower])

--- a/lib/benchee/formatters/console/run_time.ex
+++ b/lib/benchee/formatters/console/run_time.ex
@@ -11,6 +11,7 @@ defmodule Benchee.Formatters.Console.RunTime do
     Conversion,
     Conversion.Count,
     Conversion.Unit,
+    Conversion.Duration,
     Formatters.Console.Helpers,
     Statistics
   }
@@ -132,9 +133,9 @@ defmodule Benchee.Formatters.Console.RunTime do
       -label_width,
       name,
       @minimum_width,
-      Helpers.duration_output(minimum, run_time_unit),
+      duration_output(minimum, run_time_unit),
       @maximum_width,
-      Helpers.duration_output(maximum, run_time_unit),
+      duration_output(maximum, run_time_unit),
       @sample_size_width,
       Count.format(sample_size),
       @mode_width,
@@ -208,13 +209,13 @@ defmodule Benchee.Formatters.Console.RunTime do
       @ips_width,
       Helpers.count_output(ips, ips_unit),
       @average_width,
-      Helpers.duration_output(average, run_time_unit),
+      duration_output(average, run_time_unit),
       @deviation_width,
       Helpers.deviation_output(std_dev_ratio),
       @median_width,
-      Helpers.duration_output(median, run_time_unit),
+      duration_output(median, run_time_unit),
       @percentile_width,
-      Helpers.duration_output(percentile_99, run_time_unit)
+      duration_output(percentile_99, run_time_unit)
     ])
     |> to_string
   end
@@ -262,5 +263,9 @@ defmodule Benchee.Formatters.Console.RunTime do
     "~*s~*s - ~.2fx slower\n"
     |> :io_lib.format([-label_width, name, @ips_width, ips_format, slower])
     |> to_string
+  end
+
+  defp duration_output(duration, unit) do
+    Duration.format({Duration.scale(duration, unit), unit})
   end
 end

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -378,6 +378,41 @@ defmodule Benchee.Formatters.Console.MemoryTest do
       assert output =~ "Second"
       refute output =~ "x memory usage"
     end
+
+    test "it doesn't blow up if some come back with a median et. al. of nil" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          memory_usage_statistics: %Statistics{},
+          run_time_statistics: %Statistics{}
+        },
+        %Scenario{
+          name: "Second",
+          memory_usage_statistics: %Statistics{
+            average: 100.0,
+            median: 100.0,
+            sample_size: 5,
+            percentiles: %{99 => 100.0},
+            std_dev: 5.0,
+            std_dev_ratio: 0.10
+          },
+          run_time_statistics: %Statistics{}
+        }
+      ]
+
+      output =
+        Enum.join(
+          Memory.format_scenarios(scenarios, %{
+            comparison: true,
+            unit_scaling: :best,
+            extended_statistics: false
+          })
+        )
+
+      assert output =~ "First"
+      assert output =~ "Second"
+      refute output =~ "x memory usage"
+    end
   end
 
   defp assert_column_width(name, string, expected_width) do


### PR DESCRIPTION
Removing our faulty `duration_output` and using our specialized `memory_output` seemingly already fixes the problem :sweat_smile: 

Of course ideally we'd fix our memory measurements but that's a whole other topic - being more resilient is a first good step.

If this passes review I'd cherry pick release it as 0.13.2