### PR TITLE
Fix race condition in spawning tracer process

### DIFF
--- a/lib/benchee/benchmark/measure/memory.ex
+++ b/lib/benchee/benchmark/measure/memory.ex
@@ -68,10 +68,9 @@ defmodule Benchee.Benchmark.Measure.Memory do
   end
 
   defp start_tracer(pid) do
-    spawn(fn ->
-      :erlang.trace(pid, true, [:garbage_collection, tracer: self()])
-      tracer_loop(pid, 0)
-    end)
+    tracer = spawn(fn -> tracer_loop(pid, 0) end)
+    :erlang.trace(pid, true, [:garbage_collection, tracer: tracer])
+    tracer
   end
 
   defp tracer_loop(pid, acc) do

--- a/test/benchee/benchmark/measure/memory_test.exs
+++ b/test/benchee/benchmark/measure/memory_test.exs
@@ -9,7 +9,6 @@ defmodule Benchee.MemoryMeasureTest do
   @moduletag :memory_measure
 
   describe "measure/1" do
-    @tag :otp_21_memory_problems
     test "returns the result of the function and the memory used (in bytes)" do
       fun_to_run = fn -> Enum.to_list(1..10) end
       assert {memory_used, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]} = Memory.measure(fun_to_run)

--- a/test/benchee/benchmark/measure/memory_test.exs
+++ b/test/benchee/benchmark/measure/memory_test.exs
@@ -16,16 +16,16 @@ defmodule Benchee.MemoryMeasureTest do
       # We need to have some wiggle room here because memory used varies from
       # system to system. It's consistent in an environment, but changes
       # between environments.
-      assert memory_used > 350
-      assert memory_used < 380
+      assert memory_used > 380
+      assert memory_used < 460
     end
 
     test "doesn't return broken values" do
       fun = fn -> BenchKeyword.delete_v0(Enum.map(1..100, &{:"k#{&1}", &1}), :k100) end
       assert {memory_used, _} = Memory.measure(fun)
 
-      assert memory_used >= 5_000
-      assert memory_used <= 10_000
+      assert memory_used >= 8_000
+      assert memory_used <= 14_000
     end
 
     test "will not leak processes if the applied function raises an exception" do

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -135,7 +135,6 @@ defmodule Benchee.Benchmark.RunnerTest do
     end
 
     @tag :memory_measure
-    @tag :otp_21_memory_problems
     test "correctly scales down memory usage of very fast functions" do
       suite = test_suite(%Suite{configuration: %{time: 0.0, warmup: 1, memory_time: 1_000_000}})
 

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -675,7 +675,6 @@ defmodule BencheeTest do
       assert output =~ ~r/memory.+statistics/i
     end
 
-    @tag :otp_21_memory_problems
     test "the micro keyword list code from Michal does not break memory measurements #213" do
       benches = %{
         "delete old" => fn {kv, key} -> BenchKeyword.delete_v0(kv, key) end,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,14 +2,6 @@
 otp_release = List.to_integer(:erlang.system_info(:otp_release))
 exclusions = if otp_release > 18, do: [], else: [memory_measure: true]
 
-# See #234
-exclusions =
-  if otp_release >= 21 do
-    [{:otp_21_memory_problems, true} | exclusions]
-  else
-    exclusions
-  end
-
 # On Windows we have by far worse time measurements (millisecond level)
 # see: https://github.com/PragTob/benchee/pull/195#issuecomment-377010006
 {_, os} = :os.type()


### PR DESCRIPTION
We were somewhat reliably missing the first garbage collection event
because when we spawned our tracer, we were setting the tracing flag in
the function to be executed in our tracer. This means the runner and
tracer were running concurrently for a moment, and the runner hit a GC
threshold before the tracer was able to set the appropriate tracing
flag!

Now we explicitly block the runner from running the function to be run
until the tracing flag is set.

With this patch applied I now see all the GC events that we should see.

Also, I have absolutely no idea how to test this other than the tests we
already had in place.

Resolves #234 and #205 🎉 