### PR TITLE
Remove any bindings to any data allocated during measurement

### DIFF
--- a/test/benchee/benchmark/measure/memory_test.exs
+++ b/test/benchee/benchmark/measure/memory_test.exs
@@ -15,8 +15,8 @@ defmodule Benchee.MemoryMeasureTest do
       # We need to have some wiggle room here because memory used varies from
       # system to system. It's consistent in an environment, but changes
       # between environments.
-      assert memory_used > 380
-      assert memory_used < 460
+      assert memory_used > 360
+      assert memory_used < 400
     end
 
     test "doesn't return broken values" do
@@ -37,7 +37,7 @@ defmodule Benchee.MemoryMeasureTest do
       # capture it.
       capture_io(fn ->
         Memory.measure(fn -> exit(:kill) end)
-        Process.sleep(1)
+        Process.sleep(10)
       end)
 
       assert Enum.count(Process.list()) == starting_processes


### PR DESCRIPTION
This will ensure that we're collecting _only_ data that is allocated as
part of the execution of the function we're trying to benchmark. The
downside is that we end up running the function twice - once to
capture the return value and once to measure the memory usage - but
this way we're sure that we're not accidentally counting terms that
weren't directly a result of the function we're measuring.