### PR TITLE
Fix a broken link to the measuring memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The aforementioned [plugins](#plugins) like [benchee_html](https://github.com/Pr
 ## Features
 
 * first runs the functions for a given warmup time without recording the results, to simulate a _"warm"_ running system
-* [measures memory](measuring-memory-consumption)
+* [measures memory](#measuring-memory-consumption)
 * provides you with lots of statistics - check the next list
 * plugin/extensible friendly architecture so you can use different formatters to generate [CSV, HTML and more](#plugins)
 * nicely formatted console output with units scaled to appropriate units


### PR DESCRIPTION
A tiny PR fixing this link :wink: 

![pragtob benchee easy and extensible benchmarking in elixir providing you with lots of statistics](https://user-images.githubusercontent.com/128024/44162842-381c0b00-a0ca-11e8-959f-faf2b30da65c.png)
