### PR TITLE
Add Scenario.data_processed? to simplify checks in formatters

### DIFF
--- a/lib/benchee/benchmark/scenario.ex
+++ b/lib/benchee/benchmark/scenario.ex
@@ -91,7 +91,7 @@ defmodule Benchee.Benchmark.Scenario do
       iex> Scenario.data_processed?(scenario, :memory)
       false
   """
-  @spec data_processed?(t, :run_time | :memory) :: bool
+  @spec data_processed?(t, :run_time | :memory) :: boolean
   def data_processed?(scenario, :run_time) do
     scenario.run_time_statistics.sample_size > 0
   end

--- a/lib/benchee/benchmark/scenario.ex
+++ b/lib/benchee/benchmark/scenario.ex
@@ -67,4 +67,36 @@ defmodule Benchee.Benchmark.Scenario do
   def display_name(%{job_name: job_name, tag: nil}), do: job_name
   def display_name(%{job_name: job_name, tag: tag}), do: "#{job_name} (#{tag})"
   def display_name(%{job_name: job_name}), do: job_name
+
+  @doc """
+  Returns `true` if data of the provided type has been fully procsessed, `false` otherwise.
+
+  Current available types are `run_time` and `memory`. Reasons they might not have been processed
+  yet are:
+  * Suite wasn't configured to collect them at all
+  * `Benchee.statistics/1` hasn't been called yet so that data was collected but statistics
+    aren't present yet
+
+  ## Examples
+
+      iex> alias Benchee.Benchmark.Scenario
+      iex> alias Benchee.Statistics
+      iex> scenario = %Scenario{run_time_statistics: %Statistics{sample_size: 100}}
+      iex> Scenario.data_processed?(scenario, :run_time)
+      true
+      iex> scenario = %Scenario{memory_usage_statistics: %Statistics{sample_size: 1}}
+      iex> Scenario.data_processed?(scenario, :memory)
+      true
+      iex> scenario = %Scenario{memory_usage_statistics: %Statistics{sample_size: 0}}
+      iex> Scenario.data_processed?(scenario, :memory)
+      false
+  """
+  @spec data_processed?(t, :run_time | :memory) :: bool
+  def data_processed?(scenario, :run_time) do
+    scenario.run_time_statistics.sample_size > 0
+  end
+
+  def data_processed?(scenario, :memory) do
+    scenario.memory_usage_statistics.sample_size > 0
+  end
 end


### PR DESCRIPTION
Formatters often have to check whether run time or memory data
was processed - so if data was collected at all and if statistics
have already been generated so that they can be rendered.

This should simplify this/not tie all of them to the internal
data structure.

The decision as made to check directly on statistics to see if
values actually made it into it, rather than just checking the
configuration if it was intended to measure, so that we're sure
that values are there.

This might sound like a check on `Suite` to check if all scenarios
have all data might be a good thing, however mostly formatters
split things by input so it will more often be checked on a
sub set of scenarios or individual scenarios.

This PR doesn't use the function in our formatters yet, to avoid
merge conflicts with #264 :) #264 will have to adjust its
implementation though, but that should be very easy and straight
forward.