### PR TITLE
Promote Scenario to be a top level data structure

### DIFF
--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -4,8 +4,9 @@ defmodule Benchee.Benchmark do
   Exposes `benchmark/4` and `measure/3` functions.
   """
 
-  alias Benchee.Benchmark.{Runner, Scenario, ScenarioContext}
+  alias Benchee.Benchmark.{Runner, ScenarioContext}
   alias Benchee.Output.BenchmarkPrinter, as: Printer
+  alias Benchee.Scenario
   alias Benchee.Suite
   alias Benchee.Utility.DeepConvert
 

--- a/lib/benchee/benchmark/hooks.ex
+++ b/lib/benchee/benchmark/hooks.ex
@@ -2,7 +2,8 @@ defmodule Benchee.Benchmark.Hooks do
   @moduledoc false
   # Non benchee code should not rely on this module.
 
-  alias Benchee.Benchmark.{Scenario, ScenarioContext}
+  alias Benchee.Benchmark.ScenarioContext
+  alias Benchee.Scenario
 
   def run_before_scenario(
         %Scenario{

--- a/lib/benchee/benchmark/repeated_measurement.ex
+++ b/lib/benchee/benchmark/repeated_measurement.ex
@@ -21,7 +21,8 @@ defmodule Benchee.Benchmark.RepeatedMeasurement do
   # with too high variance. Therefore determine an n how often it should be
   # executed in the measurement cycle.
 
-  alias Benchee.Benchmark.{Collect, Hooks, Runner, Scenario, ScenarioContext}
+  alias Benchee.Benchmark.{Collect, Hooks, Runner, ScenarioContext}
+  alias Benchee.Scenario
   alias Benchee.Utility.RepeatN
 
   @minimum_execution_time 10

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -4,8 +4,8 @@ defmodule Benchee.Benchmark.Runner do
   # This module actually runs our benchmark scenarios, adding information about
   # run time and memory usage to each scenario.
 
-  alias Benchee.{Benchmark, Configuration, Conversion, Statistics, Utility.Parallel}
-  alias Benchmark.{Collect, Hooks, RepeatedMeasurement, Scenario, ScenarioContext}
+  alias Benchee.{Benchmark, Configuration, Conversion, Scenario, Statistics, Utility.Parallel}
+  alias Benchmark.{Collect, Hooks, RepeatedMeasurement, ScenarioContext}
 
   @doc """
   Executes the benchmarks defined before by first running the defined functions

--- a/lib/benchee/conversion.ex
+++ b/lib/benchee/conversion.ex
@@ -5,7 +5,7 @@ defmodule Benchee.Conversion do
   Can be used by plugins to use benchee unit scaling logic.
   """
 
-  alias Benchee.Benchmark.Scenario
+  alias Benchee.Scenario
   alias Benchee.Conversion.{Count, Duration, Memory}
 
   @doc """
@@ -19,7 +19,7 @@ defmodule Benchee.Conversion do
   ## Examples
 
       iex> statistics = %Benchee.Statistics{average: 1_000_000.0, ips: 1000.0}
-      iex> scenario = %Benchee.Benchmark.Scenario{
+      iex> scenario = %Benchee.Scenario{
       ...>   run_time_data: %Benchee.CollectionData{statistics: statistics},
       ...>   memory_usage_data: %Benchee.CollectionData{statistics: statistics}
       ...> }

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -22,7 +22,7 @@ defmodule Benchee.Formatters.Console do
 
   ```
   iex> scenarios = [
-  ...>   %Benchee.Benchmark.Scenario{
+  ...>   %Benchee.Scenario{
   ...>     name: "My Job", input_name: "My input", run_time_data: %Benchee.CollectionData{
   ...>       statistics: %Benchee.Statistics{
   ...>         average: 200.0,
@@ -34,7 +34,7 @@ defmodule Benchee.Formatters.Console do
   ...>       }
   ...>     }
   ...>   },
-  ...>   %Benchee.Benchmark.Scenario{
+  ...>   %Benchee.Scenario{
   ...>     name: "Job 2", input_name: "My input", run_time_data: %Benchee.CollectionData{
   ...>       statistics: %Benchee.Statistics{
   ...>         average: 400.0,

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -7,12 +7,12 @@ defmodule Benchee.Formatters.Console.Memory do
   """
 
   alias Benchee.{
-    Benchmark.Scenario,
     Conversion,
     Conversion.Count,
     Conversion.Memory,
     Conversion.Unit,
     Formatters.Console.Helpers,
+    Scenario,
     Statistics
   }
 

--- a/lib/benchee/formatters/console/run_time.ex
+++ b/lib/benchee/formatters/console/run_time.ex
@@ -7,12 +7,12 @@ defmodule Benchee.Formatters.Console.RunTime do
   """
 
   alias Benchee.{
-    Benchmark.Scenario,
     Conversion,
     Conversion.Count,
     Conversion.Duration,
     Conversion.Unit,
     Formatters.Console.Helpers,
+    Scenario,
     Statistics
   }
 
@@ -36,7 +36,7 @@ defmodule Benchee.Formatters.Console.RunTime do
   ```
   iex> memory_statistics = %Benchee.Statistics{average: 100.0}
   iex> scenarios = [
-  ...>   %Benchee.Benchmark.Scenario{
+  ...>   %Benchee.Scenario{
   ...>     name: "My Job",
   ...>     run_time_data: %Benchee.CollectionData{
   ...>       statistics: %Benchee.Statistics{
@@ -46,7 +46,7 @@ defmodule Benchee.Formatters.Console.RunTime do
   ...>     },
   ...>     memory_usage_data: %Benchee.CollectionData{statistics: memory_statistics}
   ...>   },
-  ...>   %Benchee.Benchmark.Scenario{
+  ...>   %Benchee.Scenario{
   ...>     name: "Job 2",
   ...>     run_time_data: %Benchee.CollectionData{
   ...>       statistics: %Benchee.Statistics{

--- a/lib/benchee/formatters/tagged_save.ex
+++ b/lib/benchee/formatters/tagged_save.ex
@@ -10,7 +10,7 @@ defmodule Benchee.Formatters.TaggedSave do
 
   @behaviour Benchee.Formatter
 
-  alias Benchee.Benchmark.Scenario
+  alias Benchee.Scenario
   alias Benchee.Suite
   alias Benchee.Utility.FileCreation
 

--- a/lib/benchee/scenario.ex
+++ b/lib/benchee/scenario.ex
@@ -1,4 +1,4 @@
-defmodule Benchee.Benchmark.Scenario do
+defmodule Benchee.Scenario do
   @moduledoc """
   A Scenario in Benchee is a particular case of a whole benchmarking suite. That
   is the combination of a particular function to benchmark (`job_name` and
@@ -53,7 +53,7 @@ defmodule Benchee.Benchmark.Scenario do
 
   ## Examples
 
-      iex> alias Benchee.Benchmark.Scenario
+      iex> alias Benchee.Scenario
       iex> Scenario.display_name(%Scenario{job_name: "flat_map"})
       "flat_map"
       iex> Scenario.display_name(%Scenario{job_name: "flat_map", tag: "master"})
@@ -77,7 +77,7 @@ defmodule Benchee.Benchmark.Scenario do
 
   ## Examples
 
-      iex> alias Benchee.Benchmark.Scenario
+      iex> alias Benchee.Scenario
       iex> alias Benchee.Statistics
       iex> scenario = %Scenario{run_time_data: %Benchee.CollectionData{statistics: %Statistics{sample_size: 100}}}
       iex> Scenario.data_processed?(scenario, :run_time)

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -4,7 +4,7 @@ defmodule Benchee.Statistics do
   times and then compute statistics like the average and the standard deviation.
   """
 
-  alias Benchee.{Benchmark.Scenario, Conversion.Duration, Suite, Utility.Parallel}
+  alias Benchee.{Conversion.Duration, Scenario, Suite, Utility.Parallel}
 
   alias Benchee.Statistics.Mode
   alias Benchee.Statistics.Percentile
@@ -78,7 +78,7 @@ defmodule Benchee.Statistics do
   ## Examples
 
       iex> scenarios = [
-      ...>   %Benchee.Benchmark.Scenario{
+      ...>   %Benchee.Scenario{
       ...>     job_name: "My Job",
       ...>     run_time_data: %Benchee.CollectionData{
       ...>       samples: [200, 400, 400, 400, 500, 500, 500, 700, 900]
@@ -94,7 +94,7 @@ defmodule Benchee.Statistics do
       iex> Benchee.Statistics.statistics(suite)
       %Benchee.Suite{
         scenarios: [
-          %Benchee.Benchmark.Scenario{
+          %Benchee.Scenario{
             job_name: "My Job",
             input_name: "Input",
             input: "Input",
@@ -274,7 +274,7 @@ defmodule Benchee.Statistics do
   ## Examples
 
       iex> scenarios = [
-      ...>   %Benchee.Benchmark.Scenario{
+      ...>   %Benchee.Scenario{
       ...>     job_name: "My Job",
       ...>     run_time_data: %Benchee.CollectionData{
       ...>       samples: [200, 400, 400, 400, 500, 500, 500, 700, 900]
@@ -291,7 +291,7 @@ defmodule Benchee.Statistics do
       ...> |> Benchee.Statistics.add_percentiles([25, 75])
       %Benchee.Suite{
         scenarios: [
-          %Benchee.Benchmark.Scenario{
+          %Benchee.Scenario{
             job_name: "My Job",
             input_name: "Input",
             input: "Input",

--- a/lib/benchee/suite.ex
+++ b/lib/benchee/suite.ex
@@ -21,7 +21,7 @@ defmodule Benchee.Suite do
   @type t :: %__MODULE__{
           configuration: Benchee.Configuration.t() | nil,
           system: optional_map,
-          scenarios: [] | [Benchee.Benchmark.Scenario.t()]
+          scenarios: [] | [Benchee.Scenario.t()]
         }
 end
 

--- a/test/benchee/benchmark/repeated_measurement_test.exs
+++ b/test/benchee/benchmark/repeated_measurement_test.exs
@@ -16,7 +16,8 @@ defmodule Bencheee.Benchmark.RepeatedMeasurementTest do
   use ExUnit.Case
 
   import Benchee.Benchmark.RepeatedMeasurement
-  alias Benchee.Benchmark.{Scenario, ScenarioContext}
+  alias Benchee.Benchmark.ScenarioContext
+  alias Benchee.Scenario
   alias Benchee.Test.FakeBenchmarkPrinter
   alias Bencheee.Benchmark.RepeatedMeasurementTest.FakeCollector
 

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -4,7 +4,7 @@ defmodule Benchee.Benchmark.RunnerTest do
   import Benchee.TestHelpers
   import ExUnit.CaptureIO
 
-  alias Benchee.{Benchmark, Benchmark.Scenario, Configuration, Suite}
+  alias Benchee.{Benchmark, Configuration, Scenario, Suite}
   alias Benchee.Test.FakeBenchmarkPrinter, as: TestPrinter
 
   @config %Configuration{

--- a/test/benchee/benchmark/scenario_test.exs
+++ b/test/benchee/benchmark/scenario_test.exs
@@ -1,4 +1,4 @@
-defmodule Benchee.Benchmark.ScenarioTest do
+defmodule Benchee.ScenarioTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Benchmark.Scenario
+  doctest Benchee.Scenario
 end

--- a/test/benchee/benchmark_test.exs
+++ b/test/benchee/benchmark_test.exs
@@ -3,12 +3,12 @@ defmodule Benchee.BenchmarkTest do
 
   alias Benchee.{
     Benchmark,
-    Benchmark.Scenario,
-    Benchmark.ScenarioContext,
     Configuration,
+    Scenario,
     Suite
   }
 
+  alias Benchee.Benchmark.ScenarioContext
   alias Benchee.Test.FakeBenchmarkPrinter, as: TestPrinter
   alias Benchee.Test.FakeBenchmarkRunner, as: TestRunner
 

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -2,7 +2,7 @@ defmodule Benchee.Formatters.Console.MemoryTest do
   use ExUnit.Case, async: true
   doctest Benchee.Formatters.Console.Memory
 
-  alias Benchee.{Benchmark.Scenario, CollectionData, Formatters.Console.Memory, Statistics}
+  alias Benchee.{CollectionData, Formatters.Console.Memory, Scenario, Statistics}
 
   @console_config %{
     comparison: true,

--- a/test/benchee/formatters/console/run_time_test.exs
+++ b/test/benchee/formatters/console/run_time_test.exs
@@ -2,7 +2,7 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
   use ExUnit.Case, async: true
   doctest Benchee.Formatters.Console.RunTime
 
-  alias Benchee.{Benchmark.Scenario, CollectionData, Formatters.Console.RunTime, Statistics}
+  alias Benchee.{CollectionData, Formatters.Console.RunTime, Scenario, Statistics}
 
   @console_config %{
     comparison: true,

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -5,10 +5,10 @@ defmodule Benchee.Formatters.ConsoleTest do
   import ExUnit.CaptureIO
 
   alias Benchee.{
-    Benchmark.Scenario,
     CollectionData,
     Formatter,
     Formatters.Console,
+    Scenario,
     Statistics,
     Suite
   }

--- a/test/benchee/formatters/tagged_save_test.exs
+++ b/test/benchee/formatters/tagged_save_test.exs
@@ -2,9 +2,9 @@ defmodule Benchee.Formatters.TaggedSaveTest do
   use ExUnit.Case
 
   alias Benchee.{
-    Benchmark.Scenario,
     Formatter,
     Formatters.TaggedSave,
+    Scenario,
     Statistics,
     Suite
   }

--- a/test/benchee/output/benchmark_printer_test.exs
+++ b/test/benchee/output/benchmark_printer_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Output.BenchmarkPrintertest do
   use ExUnit.Case, async: true
 
-  alias Benchee.{Benchmark, Benchmark.Scenario, Configuration}
+  alias Benchee.{Benchmark, Configuration, Scenario}
 
   import ExUnit.CaptureIO
   import Benchee.Output.BenchmarkPrinter

--- a/test/benchee/scenario_loader_test.exs
+++ b/test/benchee/scenario_loader_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.ScenarioLoaderTest do
   use ExUnit.Case
   import Benchee.ScenarioLoader
-  alias Benchee.{Benchmark.Scenario, Configuration, Suite}
+  alias Benchee.{Configuration, Scenario, Suite}
 
   test "`load` indeed loads scenarios into the suite" do
     scenarios = [%Scenario{tag: "old"}]

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -1,6 +1,6 @@
 defmodule Benchee.StatistcsTest do
   use ExUnit.Case, async: true
-  alias Benchee.{Benchmark.Scenario, CollectionData, Configuration, Statistics, Suite}
+  alias Benchee.{CollectionData, Configuration, Scenario, Statistics, Suite}
   doctest Benchee.Statistics
 
   @sample_1 [600, 470, 170, 430, 300]

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -31,7 +31,7 @@ defmodule Benchee.TestHelpers do
   def suite_without_scenario_tags(suite) do
     scenarios =
       Enum.map(suite.scenarios, fn scenario ->
-        %Benchee.Benchmark.Scenario{scenario | tag: nil, name: scenario.job_name}
+        %Benchee.Scenario{scenario | tag: nil, name: scenario.job_name}
       end)
 
     %Benchee.Suite{suite | scenarios: scenarios}


### PR DESCRIPTION
Over time Scenario has become one of our most used data structures,
perhaps the most used data structure and the most important one
besides Suite.
I mean of course, because all the important data (as in results)
is kept within a scenario. Even CollectionData is top level.
Makes no sense for Scenario to be scoped under Benchmark, as some
of the changed files also imply (as often it was the only aliased
module that was not under the top level name space)