### PR TITLE
@devonestes was right, better to make OTP compiled version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.8.0
-erlang 21.2.2
+elixir 1.8.1-otp-21
+erlang 21.2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: elixir
 elixir:
   - 1.6.6
   - 1.7.4
-  - 1.8.0
+  - 1.8.1
 otp_release:
   - 20.3
   - 21.2


### PR DESCRIPTION
Having elixir 1.8 installed which was compiled by by otp 20 while
running otp 21 seemed pretty weird.