### PR TITLE
include input_name in Table.Reader fields

### DIFF
--- a/lib/benchee/suite.ex
+++ b/lib/benchee/suite.ex
@@ -50,6 +50,7 @@ end
 
 if Code.ensure_loaded?(Table.Reader) do
   defimpl Table.Reader, for: Benchee.Suite do
+    alias Benchee.Benchmark
     alias Benchee.CollectionData
     alias Benchee.Scenario
 
@@ -96,7 +97,7 @@ if Code.ensure_loaded?(Table.Reader) do
           Enum.map(fields, fn field -> "#{measurement_type}_#{field}" end)
         end)
 
-      ["job_name" | measurement_headers]
+      ["job_name", "input_name"] ++ measurement_headers
     end
 
     defp fields_for(:run_time), do: @run_time_fields
@@ -113,7 +114,15 @@ if Code.ensure_loaded?(Table.Reader) do
             |> get_stats_from_collection_data(measurement_type, config_percentiles)
           end)
 
-        row = [scenario.job_name | secenario_data]
+        no_input = Benchmark.no_input()
+
+        input_name =
+          case scenario.input_name do
+            name when name in [nil, no_input] -> ""
+            name -> name
+          end
+
+        row = [scenario.job_name, input_name] ++ secenario_data
 
         {row, count + 1}
       end)

--- a/test/benchee/suite_test.exs
+++ b/test/benchee/suite_test.exs
@@ -225,16 +225,359 @@ defmodule Benchee.SuiteTest do
         ]
       }
 
+      @suite_with_inputs %Suite{
+        system: @system,
+        configuration: %Benchee.Configuration{
+          inputs: [
+            {"small", [1, 2, 3, 4]},
+            {"large", [1, 2, 3, 4, 5, 6, 7, 8]}
+          ],
+          input_names: ["small", "large"],
+          percentiles: [50, 99]
+        },
+        scenarios: [
+          %Benchee.Scenario{
+            input_name: "small",
+            input: [1, 2, 3, 4],
+            job_name: "Test 1",
+            memory_usage_data: %Benchee.CollectionData{
+              samples: [1_792, 1_792, 1_792],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 1_792.0,
+                ips: nil,
+                maximum: 1_792,
+                median: 1_792.0,
+                minimum: 1_792,
+                mode: 1_792,
+                percentiles: %{50 => 1_792.0, 99 => 1_792.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: +0.0,
+                std_dev_ips: nil,
+                std_dev_ratio: +0.0
+              }
+            },
+            name: "Test 1",
+            reductions_data: %Benchee.CollectionData{
+              samples: [],
+              statistics: %Benchee.Statistics{}
+            },
+            run_time_data: %Benchee.CollectionData{
+              samples: [21_580, 2_986, 11_502],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 2_854.02659820102,
+                ips: 350_382.1585371105,
+                maximum: 3_741_076,
+                median: 2_164.0,
+                minimum: 2_063,
+                mode: 2_124,
+                percentiles: %{50 => 2_164.0, 99 => 5881.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: 13_106.875011228927,
+                std_dev_ips: 1_609_100.3359973046,
+                std_dev_ratio: 4.592415158110506
+              }
+            }
+          },
+          %Benchee.Scenario{
+            job_name: "Test 2",
+            input_name: "small",
+            input: [1, 2, 3, 4],
+            memory_usage_data: %Benchee.CollectionData{
+              samples: [1_792, 1_792, 1_792],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 1_792.0,
+                ips: nil,
+                maximum: 1_792,
+                median: 1_792.0,
+                minimum: 1_792,
+                mode: 1_792,
+                percentiles: %{50 => 1_792.0, 99 => 1_792.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: +0.0,
+                std_dev_ips: nil,
+                std_dev_ratio: +0.0
+              }
+            },
+            name: "Test 2",
+            reductions_data: %Benchee.CollectionData{
+              samples: [],
+              statistics: %Benchee.Statistics{}
+            },
+            run_time_data: %Benchee.CollectionData{
+              samples: [21_580, 2_986, 11_502],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 2_854.02659820102,
+                ips: 350_382.1585371105,
+                maximum: 3_741_076,
+                median: 2_164.0,
+                minimum: 2_063,
+                mode: 2_124,
+                percentiles: %{50 => 2_164.0, 99 => 5881.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: 13_106.875011228927,
+                std_dev_ips: 1_609_100.3359973046,
+                std_dev_ratio: 4.592415158110506
+              }
+            }
+          },
+          %Benchee.Scenario{
+            job_name: "Test 1",
+            input_name: "large",
+            input: [1, 2, 3, 4, 5, 6, 7, 8],
+            memory_usage_data: %Benchee.CollectionData{
+              samples: [1_792, 1_792, 1_792],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 1_792.0,
+                ips: nil,
+                maximum: 1_792,
+                median: 1_792.0,
+                minimum: 1_792,
+                mode: 1_792,
+                percentiles: %{50 => 1_792.0, 99 => 1_792.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: +0.0,
+                std_dev_ips: nil,
+                std_dev_ratio: +0.0
+              }
+            },
+            name: "Test 1",
+            reductions_data: %Benchee.CollectionData{
+              samples: [],
+              statistics: %Benchee.Statistics{}
+            },
+            run_time_data: %Benchee.CollectionData{
+              samples: [21_580, 2_986, 11_502],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 2_854.02659820102,
+                ips: 350_382.1585371105,
+                maximum: 3_741_076,
+                median: 2_164.0,
+                minimum: 2_063,
+                mode: 2_124,
+                percentiles: %{50 => 2_164.0, 99 => 5881.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: 13_106.875011228927,
+                std_dev_ips: 1_609_100.3359973046,
+                std_dev_ratio: 4.592415158110506
+              }
+            }
+          },
+          %Benchee.Scenario{
+            job_name: "Test 2",
+            input_name: "large",
+            input: [1, 2, 3, 4, 5, 6, 7, 8],
+            memory_usage_data: %Benchee.CollectionData{
+              samples: [1_792, 1_792, 1_792],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 1_792.0,
+                ips: nil,
+                maximum: 1_792,
+                median: 1_792.0,
+                minimum: 1_792,
+                mode: 1_792,
+                percentiles: %{50 => 1_792.0, 99 => 1_792.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: +0.0,
+                std_dev_ips: nil,
+                std_dev_ratio: +0.0
+              }
+            },
+            name: "Test 2",
+            reductions_data: %Benchee.CollectionData{
+              samples: [],
+              statistics: %Benchee.Statistics{}
+            },
+            run_time_data: %Benchee.CollectionData{
+              samples: [21_580, 2_986, 11_502],
+              statistics: %Benchee.Statistics{
+                absolute_difference: nil,
+                average: 2_854.02659820102,
+                ips: 350_382.1585371105,
+                maximum: 3_741_076,
+                median: 2_164.0,
+                minimum: 2_063,
+                mode: 2_124,
+                percentiles: %{50 => 2_164.0, 99 => 5881.0},
+                relative_less: nil,
+                relative_more: nil,
+                sample_size: 3,
+                std_dev: 13_106.875011228927,
+                std_dev_ips: 1_609_100.3359973046,
+                std_dev_ratio: 4.592415158110506
+              }
+            }
+          }
+        ]
+      }
+
       test "should return a table when no scenarios are in the suite" do
         table_results = Table.Reader.init(@empty_suite)
 
         assert {:rows,
                 %{
                   columns: [
-                    "job_name"
+                    "job_name",
+                    "input_name"
                   ],
                   count: 0
                 }, []} = table_results
+      end
+
+      test "should return a table with data when multiple scenarios and inputs are in the suite" do
+        table_results = Table.Reader.init(@suite_with_inputs)
+
+        assert {:rows,
+                %{
+                  columns: [
+                    "job_name",
+                    "input_name",
+                    "run_time_samples",
+                    "run_time_ips",
+                    "run_time_average",
+                    "run_time_std_dev",
+                    "run_time_median",
+                    "run_time_minimum",
+                    "run_time_maximum",
+                    "run_time_mode",
+                    "run_time_sample_size",
+                    "run_time_p_50",
+                    "run_time_p_99",
+                    "memory_samples",
+                    "memory_average",
+                    "memory_std_dev",
+                    "memory_median",
+                    "memory_minimum",
+                    "memory_maximum",
+                    "memory_mode",
+                    "memory_sample_size",
+                    "memory_p_50",
+                    "memory_p_99"
+                  ],
+                  count: 4
+                },
+                [
+                  [
+                    "Test 1",
+                    "small",
+                    [21_580, 2_986, 11_502],
+                    350_382.1585371105,
+                    2_854.02659820102,
+                    13_106.875011228927,
+                    2_164.0,
+                    2_063,
+                    3_741_076,
+                    2_124,
+                    3,
+                    2_164.0,
+                    5881.0,
+                    [1_792, 1_792, 1_792],
+                    1_792.0,
+                    +0.0,
+                    1_792.0,
+                    1_792,
+                    1_792,
+                    1_792,
+                    3,
+                    1_792.0,
+                    1_792.0
+                  ],
+                  [
+                    "Test 2",
+                    "small",
+                    [21_580, 2_986, 11_502],
+                    350_382.1585371105,
+                    2_854.02659820102,
+                    13_106.875011228927,
+                    2_164.0,
+                    2_063,
+                    3_741_076,
+                    2_124,
+                    3,
+                    2_164.0,
+                    5881.0,
+                    [1_792, 1_792, 1_792],
+                    1_792.0,
+                    +0.0,
+                    1_792.0,
+                    1_792,
+                    1_792,
+                    1_792,
+                    3,
+                    1_792.0,
+                    1_792.0
+                  ],
+                  [
+                    "Test 1",
+                    "large",
+                    [21_580, 2_986, 11_502],
+                    350_382.1585371105,
+                    2_854.02659820102,
+                    13_106.875011228927,
+                    2_164.0,
+                    2_063,
+                    3_741_076,
+                    2_124,
+                    3,
+                    2_164.0,
+                    5881.0,
+                    [1_792, 1_792, 1_792],
+                    1_792.0,
+                    +0.0,
+                    1_792.0,
+                    1_792,
+                    1_792,
+                    1_792,
+                    3,
+                    1_792.0,
+                    1_792.0
+                  ],
+                  [
+                    "Test 2",
+                    "large",
+                    [21_580, 2_986, 11_502],
+                    350_382.1585371105,
+                    2_854.02659820102,
+                    13_106.875011228927,
+                    2_164.0,
+                    2_063,
+                    3_741_076,
+                    2_124,
+                    3,
+                    2_164.0,
+                    5881.0,
+                    [1_792, 1_792, 1_792],
+                    1_792.0,
+                    +0.0,
+                    1_792.0,
+                    1_792,
+                    1_792,
+                    1_792,
+                    3,
+                    1_792.0,
+                    1_792.0
+                  ]
+                ]} = table_results
       end
 
       test "should return a table with data when multiple scenarios are in the suite" do
@@ -244,6 +587,7 @@ defmodule Benchee.SuiteTest do
                 %{
                   columns: [
                     "job_name",
+                    "input_name",
                     "run_time_samples",
                     "run_time_ips",
                     "run_time_average",
@@ -271,6 +615,7 @@ defmodule Benchee.SuiteTest do
                 [
                   [
                     "Test 1",
+                    "",
                     [21_580, 2_986, 11_502],
                     350_382.1585371105,
                     2_854.02659820102,
@@ -295,6 +640,7 @@ defmodule Benchee.SuiteTest do
                   ],
                   [
                     "Test 2",
+                    "",
                     [21_580, 2_986, 11_502],
                     350_382.1585371105,
                     2_854.02659820102,
@@ -327,6 +673,7 @@ defmodule Benchee.SuiteTest do
                 %{
                   columns: [
                     "job_name",
+                    "input_name",
                     "run_time_samples",
                     "run_time_ips",
                     "run_time_average",
@@ -364,6 +711,7 @@ defmodule Benchee.SuiteTest do
                 [
                   [
                     "Test 1",
+                    "",
                     [21_580, 2_986, 11_502],
                     350_382.1585371105,
                     2_854.02659820102,


### PR DESCRIPTION
`Table.Reader` impl doesn't include `input_name` in the list of output fields.

When a benchmark with multiple inputs is used in a LiveBook and rendered with [kino_benchee](https://github.com/livebook-dev/kino_benchee), all results are combined into a single chart and resulting output is less useful.

https://github.com/livebook-dev/kino_benchee/pull/7 adds faceted charts to display for each input seprately, but needs this data to be exposed by Benchee.